### PR TITLE
Added ignore_ssl_errors configuration option

### DIFF
--- a/trmnl-ha/DOCS.md
+++ b/trmnl-ha/DOCS.md
@@ -66,6 +66,7 @@ bun run dev
 | `access_token` | string | *required* | HA long-lived access token |
 | `home_assistant_url` | string | `http://homeassistant:8123` | Base URL (works with any website) |
 | `keep_browser_open` | bool | `false` | Keep browser alive between requests (faster, more memory) |
+| `ignore_ssl_errors` | bool | `false` | Accept self-signed SSL certificates (for HTTPS with custom certs) |
 
 ---
 
@@ -218,6 +219,30 @@ Set VM CPU type to `host` (not `kvm64`) for Chromium sandbox compatibility.
 ### HA Connection Issues
 
 The Web UI shows diagnostic banner with status, URL, and masked token. Add `?refresh=1` to force reconnection.
+
+### HTTPS / SSL Certificate Issues
+
+If you're using HTTPS with a self-signed certificate (common with nginx/Caddy reverse proxies):
+
+**Symptoms:**
+- "Home Assistant not connected"
+- "Connection failed - could not reach HA"
+- Webhook delivery fails to local endpoints
+
+**Solution:** Enable the `ignore_ssl_errors` option in add-on configuration:
+
+1. Go to add-on **Configuration** tab
+2. Set `ignore_ssl_errors: true`
+3. Save and restart the add-on
+
+For standalone Docker users, add to `options-dev.json`:
+```json
+{
+  "ignore_ssl_errors": true
+}
+```
+
+**Note:** This is safe for home network use since you're connecting to your own Home Assistant instance.
 
 ---
 

--- a/trmnl-ha/config.yaml
+++ b/trmnl-ha/config.yaml
@@ -35,6 +35,7 @@ options:
   home_assistant_url: "http://homeassistant:8123"
   keep_browser_open: false
   debug_logging: false
+  ignore_ssl_errors: false
 
 # Schema for options validation
 schema:
@@ -42,6 +43,7 @@ schema:
   home_assistant_url: str?
   keep_browser_open: bool?
   debug_logging: bool?
+  ignore_ssl_errors: bool?
 
 # Exclude regeneratable data from HA backups
 backup_exclude:

--- a/trmnl-ha/ha-trmnl/const.ts
+++ b/trmnl-ha/ha-trmnl/const.ts
@@ -22,6 +22,7 @@ interface Options {
   chromium_executable?: string
   keep_browser_open?: boolean
   debug_logging?: boolean
+  ignore_ssl_errors?: boolean
 }
 
 /**
@@ -116,6 +117,21 @@ export const keepBrowserOpen: boolean = options.keep_browser_open ?? false
  * Default: true for development, controlled by options in production
  */
 export const debugLogging: boolean = options.debug_logging ?? true
+
+/**
+ * Ignore SSL certificate errors (from HA add-on configuration)
+ * When true, accepts self-signed certificates for HTTPS connections
+ * Required for users with custom SSL certs on their HA instance
+ * Default: false (strict SSL validation)
+ */
+export const ignoreSslErrors: boolean = options.ignore_ssl_errors ?? false
+
+// Apply SSL settings to Node/Bun TLS stack (affects fetch, WebSocket, etc.)
+// NOTE: Must be set before any TLS connections are made
+if (ignoreSslErrors) {
+  process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0'
+  console.log('[SSL] Ignoring SSL certificate errors (configured in add-on settings)')
+}
 
 // =============================================================================
 // SERVER CONFIGURATION

--- a/trmnl-ha/ha-trmnl/options-dev.json.example
+++ b/trmnl-ha/ha-trmnl/options-dev.json.example
@@ -5,5 +5,8 @@
   "access_token": "",
 
   "keep_browser_open": true,
-  "chromium_executable": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+  "chromium_executable": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+
+  "_ssl_readme": "Set to true if using self-signed SSL certificates",
+  "ignore_ssl_errors": false
 }


### PR DESCRIPTION
Note: This solution is not ideal. Would rather load the certs. Gonna pick this up later.


Users with HTTPS and self-signed certificates were unable to connect to Home Assistant, receiving "Connection failed - could not reach HA" errors.

This adds a configurable option that:
- Passes --ignore-certificate-errors to Chromium for browser connections
- Sets NODE_TLS_REJECT_UNAUTHORIZED=0 for WebSocket/fetch calls

Made opt-in (default false) rather than always-on to maintain strict SSL validation for users who prefer it.