### PR TITLE
Fixed washed-out gray output by enabling normalize for all palettes

### DIFF
--- a/trmnl-ha/ha-trmnl/html/js/schedule-manager.ts
+++ b/trmnl-ha/ha-trmnl/html/js/schedule-manager.ts
@@ -12,7 +12,11 @@ import {
   UpdateSchedule,
   DeleteSchedule,
 } from './api-client.js'
-import type { Schedule, ScheduleInput, ScheduleUpdate } from '../../types/domain.js'
+import type {
+  Schedule,
+  ScheduleInput,
+  ScheduleUpdate,
+} from '../../types/domain.js'
 
 /**
  * Schedule state manager coordinating CRUD operations and selection.
@@ -101,7 +105,7 @@ export class ScheduleManager {
         gammaCorrection: true,
         blackLevel: 0,
         whiteLevel: 100,
-        normalize: false,
+        normalize: true, // Enabled by default to prevent gray/washed-out output (issue #9)
         saturationBoost: false,
       },
     }

--- a/trmnl-ha/ha-trmnl/html/shared/build-screenshot-params.ts
+++ b/trmnl-ha/ha-trmnl/html/shared/build-screenshot-params.ts
@@ -111,9 +111,9 @@ export function buildScreenshotParams(
       }
     }
 
-    // Normalize
-    if (schedule.dithering.normalize) {
-      params.append('normalize', '')
+    // Normalize (default is enabled, so we send no_normalize when disabled)
+    if (schedule.dithering.normalize === false) {
+      params.append('no_normalize', '')
     }
 
     // Saturation boost

--- a/trmnl-ha/ha-trmnl/lib/dithering.ts
+++ b/trmnl-ha/ha-trmnl/lib/dithering.ts
@@ -142,7 +142,9 @@ export function validateDitheringOptions(
       options.gammaCorrection !== undefined ? options.gammaCorrection : true,
     blackLevel: Math.max(0, Math.min(100, options.blackLevel ?? 0)),
     whiteLevel: Math.max(0, Math.min(100, options.whiteLevel ?? 100)),
-    normalize: options.normalize !== undefined ? options.normalize : isColor,
+    // NOTE: normalize defaults to true for ALL palettes (including grayscale)
+    // to prevent washed-out gray output. See GitHub issue #9.
+    normalize: options.normalize ?? true,
     saturationBoost:
       options.saturationBoost !== undefined ? options.saturationBoost : isColor,
     rotate: VALID_ROTATIONS.includes(options.rotate as RotationAngle)
@@ -433,9 +435,11 @@ export async function applyDithering(
     palette && GRAYSCALE_PALETTES[palette as GrayscalePalette]
   )
 
-  // Smart defaults: enable normalize and saturationBoost for color palettes
-  // unless explicitly set to false by the caller
-  const normalize = options.normalize ?? isColorPaletteMode
+  // Smart defaults:
+  // - normalize: enabled by default for ALL palettes to prevent gray/washed-out output
+  // - saturationBoost: enabled by default only for color palettes
+  // See GitHub issue #9 for gray background root cause analysis.
+  const normalize = options.normalize ?? true
   const saturationBoost = options.saturationBoost ?? isColorPaletteMode
 
   let image: State = gm(imageBuffer)

--- a/trmnl-ha/ha-trmnl/lib/screenshot-params-parser.ts
+++ b/trmnl-ha/ha-trmnl/lib/screenshot-params-parser.ts
@@ -180,7 +180,7 @@ export class ScreenshotParamsParser {
     if (isNaN(whiteLevel) || whiteLevel < 0 || whiteLevel > 100)
       whiteLevel = 100
 
-    const normalize = url.searchParams.has('normalize')
+    const normalize = !url.searchParams.has('no_normalize')
     const saturationBoost = url.searchParams.has('saturation_boost')
 
     let bitDepth: BitDepth | undefined

--- a/trmnl-ha/ha-trmnl/tests/unit/dithering.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/dithering.test.ts
@@ -136,11 +136,25 @@ describe.skip('Dithering Module', () => {
       expect(result.whiteLevel).toBe(100)
     })
 
-    it('enables normalize and saturationBoost for color palettes', () => {
-      const result = validateDitheringOptions({ palette: 'color-7a' })
+    it('enables normalize by default for all palettes (fix for gray background issue #9)', () => {
+      // Grayscale palette - normalize should be true by default
+      const grayscaleResult = validateDitheringOptions({ palette: 'gray-4' })
+      expect(grayscaleResult.normalize).toBe(true)
+      expect(grayscaleResult.saturationBoost).toBe(false) // Only for color
 
-      expect(result.normalize).toBe(true)
-      expect(result.saturationBoost).toBe(true)
+      // Color palette - both normalize and saturationBoost should be true
+      const colorResult = validateDitheringOptions({ palette: 'color-7a' })
+      expect(colorResult.normalize).toBe(true)
+      expect(colorResult.saturationBoost).toBe(true)
+    })
+
+    it('respects explicit normalize=false override', () => {
+      const result = validateDitheringOptions({
+        palette: 'gray-4',
+        normalize: false,
+      })
+
+      expect(result.normalize).toBe(false)
     })
   })
 

--- a/trmnl-ha/ha-trmnl/tests/unit/screenshot-params-parser.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/screenshot-params-parser.test.ts
@@ -522,16 +522,27 @@ describe('ScreenshotParamsParser', () => {
       expect(result!.dithering!.whiteLevel).toBe(100)
     })
 
-    it('parses normalize flag when present', () => {
+    it('defaults normalize to true when no_normalize is absent', () => {
       const url = createUrl('/lovelace/0', {
         viewport: '800x600',
         dithering: true,
-        normalize: true,
       })
 
       const result = parser.call(url)
 
       expect(result!.dithering!.normalize).toBe(true)
+    })
+
+    it('parses no_normalize flag to disable normalization', () => {
+      const url = createUrl('/lovelace/0', {
+        viewport: '800x600',
+        dithering: true,
+        no_normalize: true,
+      })
+
+      const result = parser.call(url)
+
+      expect(result!.dithering!.normalize).toBe(false)
     })
 
     it('parses saturationBoost flag when present', () => {


### PR DESCRIPTION
Grayscale screenshots were appearing washed-out because normalize was only enabled by default for color palettes. Root cause analysis revealed that normalize prevents gray backgrounds on e-ink displays regardless of palette type.

Changes include:
- Dithering now defaults normalize to true for all palettes
- Frontend sends no_normalize flag instead of normalize (opt-out vs opt-in)
- Schedule migration ensures existing schedules get the correct default
- Webhook errors now include parsed error details for better UI feedback

Issue: #9