### PR TITLE
Added Cyan and 8-color palette support for e-ink displays

### DIFF
--- a/trmnl-ha/ha-trmnl/const.ts
+++ b/trmnl-ha/ha-trmnl/const.ts
@@ -176,24 +176,50 @@ export const VALID_ROTATIONS: readonly RotationAngle[] = [90, 180, 270] as const
 
 /**
  * Color palette definitions for e-ink displays
+ *
+ * @see https://www.eink.com/brand/detail/Spectra6
+ * @see https://shop.pimoroni.com/products/inky-impression-7-3
  */
 export const COLOR_PALETTES: ColorPaletteDefinition = {
+  // 6-color: Basic RGB + Yellow + Black/White
   'color-6a': [
-    '#FF0000',
-    '#00FF00',
-    '#0000FF',
-    '#FFFF00',
-    '#000000',
-    '#FFFFFF',
+    '#000000', // Black
+    '#FFFFFF', // White
+    '#FF0000', // Red
+    '#00FF00', // Green
+    '#0000FF', // Blue
+    '#FFFF00', // Yellow
   ],
+  // 7-color ACeP/Gallery with Orange (Waveshare, Pimoroni Inky Impression)
   'color-7a': [
-    '#000000',
-    '#FFFFFF',
-    '#FF0000',
-    '#00FF00',
-    '#0000FF',
-    '#FFFF00',
-    '#FFA500',
+    '#000000', // Black
+    '#FFFFFF', // White
+    '#FF0000', // Red
+    '#00FF00', // Green
+    '#0000FF', // Blue
+    '#FFFF00', // Yellow
+    '#FF8C00', // Orange (Dark Orange - per Pimoroni spec)
+  ],
+  // 7-color with Cyan (for displays that have Cyan instead of Orange)
+  'color-7b': [
+    '#000000', // Black
+    '#FFFFFF', // White
+    '#FF0000', // Red
+    '#00FF00', // Green
+    '#0000FF', // Blue
+    '#FFFF00', // Yellow
+    '#00FFFF', // Cyan
+  ],
+  // 8-color Spectra 6 T2000 (2025+) - has both Cyan AND Orange
+  'color-8a': [
+    '#000000', // Black
+    '#FFFFFF', // White
+    '#FF0000', // Red
+    '#00FF00', // Green
+    '#0000FF', // Blue
+    '#FFFF00', // Yellow
+    '#00FFFF', // Cyan
+    '#FF8C00', // Orange
   ],
 }
 

--- a/trmnl-ha/ha-trmnl/devices.json
+++ b/trmnl-ha/ha-trmnl/devices.json
@@ -371,6 +371,56 @@
     "createdAt": "2025-11-19T00:00:00.000Z",
     "updatedAt": "2025-11-19T00:00:00.000Z"
   },
+  "schedule_7color_cyan": {
+    "name": "7-Color (Cyan)",
+    "cron": "0 * * * *",
+    "dashboard_path": "/lovelace/0",
+    "viewport": {
+      "width": 800,
+      "height": 480
+    },
+    "webhook_url": "",
+    "format": "png",
+    "rotate": 0,
+    "dithering": {
+      "enabled": true,
+      "method": "floyd-steinberg",
+      "palette": "color-7b",
+      "gammaCorrection": true,
+      "blackLevel": 0,
+      "whiteLevel": 100,
+      "normalize": true,
+      "saturationBoost": true
+    },
+    "id": "schedule_7color_cyan",
+    "createdAt": "2025-11-19T00:00:00.000Z",
+    "updatedAt": "2025-11-19T00:00:00.000Z"
+  },
+  "schedule_spectra6_t2000": {
+    "name": "Spectra 6 T2000 (8-color)",
+    "cron": "0 * * * *",
+    "dashboard_path": "/lovelace/0",
+    "viewport": {
+      "width": 800,
+      "height": 480
+    },
+    "webhook_url": "",
+    "format": "png",
+    "rotate": 0,
+    "dithering": {
+      "enabled": true,
+      "method": "floyd-steinberg",
+      "palette": "color-8a",
+      "gammaCorrection": true,
+      "blackLevel": 0,
+      "whiteLevel": 100,
+      "normalize": true,
+      "saturationBoost": true
+    },
+    "id": "schedule_spectra6_t2000",
+    "createdAt": "2025-11-19T00:00:00.000Z",
+    "updatedAt": "2025-11-19T00:00:00.000Z"
+  },
   "schedule_inkplate_10": {
     "name": "Inkplate 10",
     "cron": "0 * * * *",

--- a/trmnl-ha/ha-trmnl/types/domain.ts
+++ b/trmnl-ha/ha-trmnl/types/domain.ts
@@ -39,7 +39,11 @@ export type RotationAngle = 90 | 180 | 270
 export type GrayscalePalette = 'bw' | 'gray-4' | 'gray-16' | 'gray-256'
 
 /** Color palette types for color e-ink displays */
-export type ColorPalette = 'color-6a' | 'color-7a'
+export type ColorPalette =
+  | 'color-6a' // 6-color: R, G, B, Y, Black, White
+  | 'color-7a' // 7-color ACeP/Gallery with Orange
+  | 'color-7b' // 7-color with Cyan (instead of Orange)
+  | 'color-8a' // 8-color Spectra 6 T2000 (both Cyan + Orange)
 
 /** All supported palettes */
 export type Palette = GrayscalePalette | ColorPalette


### PR DESCRIPTION
Fixes https://github.com/usetrmnl/trmnl-home-assistant/issues/3

Different e-ink display technologies use different color palettes:
- ACeP/Gallery displays output Orange (no Cyan)
- Spectra 6 T2000 (2025+) supports both Cyan and Orange

This enables proper color mapping for displays that have Cyan instead of Orange, and for newer 8-color Spectra 6 panels.

- color-7b: 7-color palette with Cyan (replaces Orange)
- color-8a: 8-color Spectra 6 T2000 (Cyan + Orange)
- Device presets for both new palette types