### PR TITLE
Added first-class Docker Container support with environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Send Home Assistant dashboard screenshots to your TRMNL e-ink display with advan
 
 ## Installation
 
+### Home Assistant OS (Recommended)
+
 1. Add this repository to Home Assistant:
    - Go to **Settings** → **Add-ons** → **Add-on Store** → **⋮** → **Repositories**
    - Add: `https://github.com/usetrmnl/trmnl-home-assistant`
@@ -32,6 +34,26 @@ Send Home Assistant dashboard screenshots to your TRMNL e-ink display with advan
    - Add to the add-on configuration
 
 4. Start the add-on and open the Web UI
+
+### Home Assistant Container (Docker)
+
+Running HA as a Docker container? No problem! Just one command:
+
+```bash
+docker run -d --name trmnl-ha \
+  --restart unless-stopped \
+  -e HOME_ASSISTANT_URL=http://YOUR_HOST_IP:8123 \
+  -e ACCESS_TOKEN=your_token_here \
+  -p 10000:10000 \
+  -v ./trmnl-data:/data \
+  ghcr.io/usetrmnl/trmnl-ha-amd64:latest # ARM64 (Pi 4/5, Apple Silicon): ghcr.io/usetrmnl/trmnl-ha-aarch64:latest
+```
+
+> **Note:** Replace `YOUR_HOST_IP` with your machine's IP (e.g., `192.168.1.100`). Container names like `homeassistant` won't work since HA uses host networking.
+
+Then open `http://localhost:10000` - that's it!
+
+See [full Docker setup](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#home-assistant-container-docker) for Docker Compose and timezone configuration.
 
 ### Proxmox Users
 

--- a/trmnl-ha/README.md
+++ b/trmnl-ha/README.md
@@ -21,6 +21,8 @@ Send Home Assistant dashboard screenshots to your TRMNL e-ink display with advan
 
 ## Installation
 
+### Home Assistant OS (Recommended)
+
 1. Add this repository to Home Assistant:
    - Go to **Settings** → **Add-ons** → **Add-on Store** → **⋮** → **Repositories**
    - Add: `https://github.com/usetrmnl/trmnl-home-assistant`
@@ -32,6 +34,26 @@ Send Home Assistant dashboard screenshots to your TRMNL e-ink display with advan
    - Add to the add-on configuration
 
 4. Start the add-on and open the Web UI
+
+### Home Assistant Container (Docker)
+
+Running HA as a Docker container? No problem! Just one command:
+
+```bash
+docker run -d --name trmnl-ha \
+  --restart unless-stopped \
+  -e HOME_ASSISTANT_URL=http://YOUR_HOST_IP:8123 \
+  -e ACCESS_TOKEN=your_token_here \
+  -p 10000:10000 \
+  -v ./trmnl-data:/data \
+  ghcr.io/usetrmnl/trmnl-ha-amd64:latest
+```
+
+> **Note:** Replace `YOUR_HOST_IP` with your machine's IP (e.g., `192.168.1.100`). Container names like `homeassistant` won't work since HA uses host networking.
+
+Then open `http://localhost:10000` - that's it!
+
+See [full Docker setup](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#home-assistant-container-docker) for Docker Compose and timezone configuration.
 
 ### Proxmox Users
 

--- a/trmnl-ha/config.yaml
+++ b/trmnl-ha/config.yaml
@@ -33,6 +33,7 @@ ports_description:
 options:
   access_token: ""
   home_assistant_url: "http://homeassistant:8123"
+  timezone: ""
   keep_browser_open: false
   debug_logging: false
 
@@ -40,6 +41,7 @@ options:
 schema:
   access_token: str
   home_assistant_url: str?
+  timezone: str?
   keep_browser_open: bool?
   debug_logging: bool?
 

--- a/trmnl-ha/ha-trmnl/lib/config-helpers.ts
+++ b/trmnl-ha/ha-trmnl/lib/config-helpers.ts
@@ -1,0 +1,111 @@
+/**
+ * Pure helper functions for configuration logic
+ * Extracted from const.ts for testability
+ *
+ * @module lib/config-helpers
+ */
+
+import { existsSync } from 'fs'
+
+/**
+ * Common browser paths by platform
+ * Puppeteer will use its bundled Chromium if none are found
+ */
+export const BROWSER_PATHS = [
+  // Docker / Linux
+  '/usr/bin/chromium',
+  '/usr/bin/chromium-browser',
+  '/usr/bin/google-chrome',
+  '/usr/bin/google-chrome-stable',
+  // macOS
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  '/Applications/Chromium.app/Contents/MacOS/Chromium',
+  // Windows (WSL paths)
+  '/mnt/c/Program Files/Google/Chrome/Application/chrome.exe',
+  '/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe',
+] as const
+
+/**
+ * Find first available browser executable from known paths
+ * @returns Path to browser executable, or undefined if none found
+ */
+export function findBrowser(): string | undefined {
+  return BROWSER_PATHS.find(existsSync)
+}
+
+/**
+ * Validate timezone against IANA timezone database
+ * @param timezone - Timezone string to validate (e.g., "America/New_York")
+ * @returns true if timezone is valid IANA timezone name
+ */
+export function isValidTimezone(timezone: string): boolean {
+  const validTimezones = Intl.supportedValuesOf('timeZone')
+  return validTimezones.includes(timezone)
+}
+
+/**
+ * Check if running with environment variable configuration
+ * @param env - Environment variables object (defaults to process.env)
+ * @returns true if HOME_ASSISTANT_URL or ACCESS_TOKEN env vars are set
+ */
+export function hasEnvConfig(
+  env: Record<string, string | undefined> = process.env
+): boolean {
+  return Boolean(env['HOME_ASSISTANT_URL'] || env['ACCESS_TOKEN'])
+}
+
+/**
+ * Determine if running as Home Assistant add-on
+ *
+ * Detection methods (in order of reliability):
+ * 1. SUPERVISOR_TOKEN env var - injected by HA Supervisor into all add-ons
+ * 2. /data/options.json exists without env config - fallback for edge cases
+ *
+ * @param env - Environment variables object
+ * @param optionsFile - Path to options file (if found)
+ * @returns true if running as HA add-on, false for standalone mode
+ */
+export function detectIsAddOn(
+  env: Record<string, string | undefined>,
+  optionsFile: string | undefined
+): boolean {
+  return Boolean(
+    env['SUPERVISOR_TOKEN'] ||
+      (optionsFile === '/data/options.json' && !hasEnvConfig(env))
+  )
+}
+
+/**
+ * Parse boolean from environment variable string
+ * @param value - String value from env var
+ * @param defaultValue - Default if undefined
+ * @returns Parsed boolean value
+ */
+export function parseEnvBoolean(
+  value: string | undefined,
+  defaultValue: boolean
+): boolean {
+  if (value === undefined) return defaultValue
+  return value === 'true'
+}
+
+/**
+ * Network error detection patterns
+ */
+export const NETWORK_ERROR_PATTERNS = [
+  'Network error',
+  'ERR_NAME_NOT_RESOLVED',
+  'ERR_CONNECTION_REFUSED',
+  'ERR_INTERNET_DISCONNECTED',
+] as const
+
+/**
+ * Check if error is a network-related error
+ * @param error - Error to check
+ * @returns true if error message contains network error patterns
+ */
+export function isNetworkError(error: Error): boolean {
+  return NETWORK_ERROR_PATTERNS.some((pattern) =>
+    error.message?.includes(pattern)
+  )
+}

--- a/trmnl-ha/ha-trmnl/tests/unit/config-helpers.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/config-helpers.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Unit tests for Configuration Helpers
+ *
+ * Tests pure functions extracted from const.ts for:
+ * - Timezone validation
+ * - Environment detection
+ * - Browser path detection
+ * - Network error detection
+ *
+ * @module tests/unit/config-helpers
+ */
+
+import { describe, it, expect } from 'bun:test'
+import {
+  isValidTimezone,
+  hasEnvConfig,
+  detectIsAddOn,
+  parseEnvBoolean,
+  isNetworkError,
+  BROWSER_PATHS,
+  NETWORK_ERROR_PATTERNS,
+} from '../../lib/config-helpers.js'
+
+// =============================================================================
+// Timezone Validation
+// =============================================================================
+
+describe('isValidTimezone', () => {
+  describe('valid IANA timezone names', () => {
+    it('accepts America/New_York', () => {
+      expect(isValidTimezone('America/New_York')).toBe(true)
+    })
+
+    it('accepts Europe/London', () => {
+      expect(isValidTimezone('Europe/London')).toBe(true)
+    })
+
+    it('accepts Asia/Tokyo', () => {
+      expect(isValidTimezone('Asia/Tokyo')).toBe(true)
+    })
+
+    it('accepts UTC', () => {
+      expect(isValidTimezone('UTC')).toBe(true)
+    })
+
+    it('accepts Pacific/Auckland', () => {
+      expect(isValidTimezone('Pacific/Auckland')).toBe(true)
+    })
+
+    it('accepts Etc/GMT offset format', () => {
+      expect(isValidTimezone('Etc/GMT+5')).toBe(true)
+    })
+  })
+
+  describe('invalid timezone values', () => {
+    it('rejects EST abbreviation', () => {
+      expect(isValidTimezone('EST')).toBe(false)
+    })
+
+    it('rejects PST abbreviation', () => {
+      expect(isValidTimezone('PST')).toBe(false)
+    })
+
+    it('rejects GMT abbreviation', () => {
+      expect(isValidTimezone('GMT')).toBe(false)
+    })
+
+    it('rejects bogus timezone', () => {
+      expect(isValidTimezone('Fake/City')).toBe(false)
+    })
+
+    it('rejects empty string', () => {
+      expect(isValidTimezone('')).toBe(false)
+    })
+
+    it('rejects offset format', () => {
+      expect(isValidTimezone('UTC+5')).toBe(false)
+    })
+
+    it('rejects numeric offset', () => {
+      expect(isValidTimezone('+05:30')).toBe(false)
+    })
+  })
+})
+
+// =============================================================================
+// Environment Config Detection
+// =============================================================================
+
+describe('hasEnvConfig', () => {
+  it('returns true when HOME_ASSISTANT_URL is set', () => {
+    const env = { HOME_ASSISTANT_URL: 'http://192.168.1.100:8123' }
+
+    expect(hasEnvConfig(env)).toBe(true)
+  })
+
+  it('returns true when ACCESS_TOKEN is set', () => {
+    const env = { ACCESS_TOKEN: 'my-token' }
+
+    expect(hasEnvConfig(env)).toBe(true)
+  })
+
+  it('returns true when both are set', () => {
+    const env = {
+      HOME_ASSISTANT_URL: 'http://192.168.1.100:8123',
+      ACCESS_TOKEN: 'my-token',
+    }
+
+    expect(hasEnvConfig(env)).toBe(true)
+  })
+
+  it('returns false when neither is set', () => {
+    const env = {}
+
+    expect(hasEnvConfig(env)).toBe(false)
+  })
+
+  it('returns false when values are undefined', () => {
+    const env = {
+      HOME_ASSISTANT_URL: undefined,
+      ACCESS_TOKEN: undefined,
+    }
+
+    expect(hasEnvConfig(env)).toBe(false)
+  })
+
+  it('returns false when values are empty strings', () => {
+    const env = {
+      HOME_ASSISTANT_URL: '',
+      ACCESS_TOKEN: '',
+    }
+
+    expect(hasEnvConfig(env)).toBe(false)
+  })
+})
+
+// =============================================================================
+// Add-on Detection
+// =============================================================================
+
+describe('detectIsAddOn', () => {
+  describe('SUPERVISOR_TOKEN detection (primary method)', () => {
+    it('returns true when SUPERVISOR_TOKEN is present', () => {
+      const env = { SUPERVISOR_TOKEN: 'abc123' }
+
+      expect(detectIsAddOn(env, undefined)).toBe(true)
+    })
+
+    it('returns true even with env config when SUPERVISOR_TOKEN present', () => {
+      const env = {
+        SUPERVISOR_TOKEN: 'abc123',
+        HOME_ASSISTANT_URL: 'http://192.168.1.100:8123',
+      }
+
+      expect(detectIsAddOn(env, '/data/options.json')).toBe(true)
+    })
+  })
+
+  describe('options file detection (fallback method)', () => {
+    it('returns true for /data/options.json without env config', () => {
+      const env = {}
+
+      expect(detectIsAddOn(env, '/data/options.json')).toBe(true)
+    })
+
+    it('returns false for /data/options.json WITH env config', () => {
+      const env = { HOME_ASSISTANT_URL: 'http://192.168.1.100:8123' }
+
+      expect(detectIsAddOn(env, '/data/options.json')).toBe(false)
+    })
+
+    it('returns false for options-dev.json', () => {
+      const env = {}
+
+      expect(detectIsAddOn(env, './options-dev.json')).toBe(false)
+    })
+  })
+
+  describe('standalone mode detection', () => {
+    it('returns false when using env vars only', () => {
+      const env = {
+        HOME_ASSISTANT_URL: 'http://192.168.1.100:8123',
+        ACCESS_TOKEN: 'my-token',
+      }
+
+      expect(detectIsAddOn(env, undefined)).toBe(false)
+    })
+
+    it('returns false for local dev with options-dev.json', () => {
+      const env = {}
+
+      expect(detectIsAddOn(env, './options-dev.json')).toBe(false)
+    })
+
+    it('returns false when no config at all', () => {
+      const env = {}
+
+      expect(detectIsAddOn(env, undefined)).toBe(false)
+    })
+  })
+})
+
+// =============================================================================
+// Boolean Environment Variable Parsing
+// =============================================================================
+
+describe('parseEnvBoolean', () => {
+  it('returns true for "true" string', () => {
+    expect(parseEnvBoolean('true', false)).toBe(true)
+  })
+
+  it('returns false for "false" string', () => {
+    expect(parseEnvBoolean('false', true)).toBe(false)
+  })
+
+  it('returns false for any non-"true" string', () => {
+    expect(parseEnvBoolean('yes', true)).toBe(false)
+    expect(parseEnvBoolean('1', true)).toBe(false)
+    expect(parseEnvBoolean('TRUE', true)).toBe(false)
+  })
+
+  it('returns default when undefined', () => {
+    expect(parseEnvBoolean(undefined, true)).toBe(true)
+    expect(parseEnvBoolean(undefined, false)).toBe(false)
+  })
+
+  it('returns false for empty string', () => {
+    expect(parseEnvBoolean('', true)).toBe(false)
+  })
+})
+
+// =============================================================================
+// Network Error Detection
+// =============================================================================
+
+describe('isNetworkError', () => {
+  it('detects "Network error"', () => {
+    const error = new Error('Network error occurred')
+
+    expect(isNetworkError(error)).toBe(true)
+  })
+
+  it('detects ERR_NAME_NOT_RESOLVED', () => {
+    const error = new Error('net::ERR_NAME_NOT_RESOLVED')
+
+    expect(isNetworkError(error)).toBe(true)
+  })
+
+  it('detects ERR_CONNECTION_REFUSED', () => {
+    const error = new Error('net::ERR_CONNECTION_REFUSED at http://localhost')
+
+    expect(isNetworkError(error)).toBe(true)
+  })
+
+  it('detects ERR_INTERNET_DISCONNECTED', () => {
+    const error = new Error('ERR_INTERNET_DISCONNECTED')
+
+    expect(isNetworkError(error)).toBe(true)
+  })
+
+  it('returns false for non-network errors', () => {
+    const error = new Error('Timeout exceeded')
+
+    expect(isNetworkError(error)).toBe(false)
+  })
+
+  it('returns false for generic errors', () => {
+    const error = new Error('Something went wrong')
+
+    expect(isNetworkError(error)).toBe(false)
+  })
+
+  it('handles errors without message', () => {
+    const error = new Error()
+
+    expect(isNetworkError(error)).toBe(false)
+  })
+})
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+describe('BROWSER_PATHS', () => {
+  it('includes Linux Chromium paths', () => {
+    expect(BROWSER_PATHS).toContain('/usr/bin/chromium')
+    expect(BROWSER_PATHS).toContain('/usr/bin/chromium-browser')
+  })
+
+  it('includes Linux Chrome paths', () => {
+    expect(BROWSER_PATHS).toContain('/usr/bin/google-chrome')
+    expect(BROWSER_PATHS).toContain('/usr/bin/google-chrome-stable')
+  })
+
+  it('includes macOS paths', () => {
+    expect(BROWSER_PATHS).toContain(
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+    )
+  })
+
+  it('includes WSL paths', () => {
+    expect(BROWSER_PATHS).toContain(
+      '/mnt/c/Program Files/Google/Chrome/Application/chrome.exe'
+    )
+  })
+
+  it('prioritizes Docker/Linux paths first', () => {
+    // First paths should be Linux for Docker compatibility
+    expect(BROWSER_PATHS[0]).toBe('/usr/bin/chromium')
+  })
+})
+
+describe('NETWORK_ERROR_PATTERNS', () => {
+  it('includes common network error patterns', () => {
+    expect(NETWORK_ERROR_PATTERNS).toContain('Network error')
+    expect(NETWORK_ERROR_PATTERNS).toContain('ERR_NAME_NOT_RESOLVED')
+    expect(NETWORK_ERROR_PATTERNS).toContain('ERR_CONNECTION_REFUSED')
+    expect(NETWORK_ERROR_PATTERNS).toContain('ERR_INTERNET_DISCONNECTED')
+  })
+
+  it('has 4 patterns', () => {
+    expect(NETWORK_ERROR_PATTERNS.length).toBe(4)
+  })
+})


### PR DESCRIPTION
Home Assistant Container users don't have access to the add-on store, so they couldn't use TRMNL HA with the same straightforwardness.
This adds support for running as a standalone Docker container with configuration via environment variables.

Changes:
- Environment variables (HOME_ASSISTANT_URL, ACCESS_TOKEN, TZ, etc.) now take precedence over JSON config files
- Platform-agnostic browser detection across Docker, macOS, Linux, WSL
- Timezone configuration for correct scheduled capture timing
- Documentation with docker-compose examples and network_mode: host gotcha