### PR TITLE
Fix manual levels rendering by aligning ImageMagick `-level` arguments

### DIFF
--- a/trmnl-ha/ha-trmnl/lib/dithering.ts
+++ b/trmnl-ha/ha-trmnl/lib/dithering.ts
@@ -565,10 +565,8 @@ function applyGrayscaleDithering(
   if (levelsEnabled && (blackLevel > 0 || whiteLevel < 100)) {
     const blackPoint = `${blackLevel}%`
     const whitePoint = `${whiteLevel}%`
-    // NOTE: gm .level() accepts strings but @types/gm is incomplete
-    image = (
-      image as State & { level(b: string, g: number, w: string): State }
-    ).level(blackPoint, 1.0, whitePoint)
+    // NOTE: gm.level() uses GraphicsMagick arg order; ImageMagick expects black,white,gamma.
+    image = image.out('-level', `${blackPoint},${whitePoint}`)
   }
 
   // Select and apply dithering strategy


### PR DESCRIPTION
Manual Levels were producing nearly black previews even with mild settings. The root cause was argument order: `gm.level()` follows `GraphicsMagick’s black,gamma,white`, while our pipeline runs ImageMagick, which expects `black,white,gamma`.
That mismatch effectively applied an unintended gamma and crushed mid‑tones.

This change bypasses `gm.level()` and emits ImageMagick’s `-level black%,white%` directly in the grayscale dithering path. It keeps the intended black/white point adjustments without disturbing the rest of the pipeline (normalize, dithering method, palette selection).

# Before/After
<img width="2418" height="1318" alt="before" src="https://github.com/user-attachments/assets/0a7f8bf1-bfeb-4bae-8bc9-d031c74866c4" />
<img width="2400" height="1310" alt="after" src="https://github.com/user-attachments/assets/d90dd70f-7924-4298-b7fc-5bb9082a2e77" />

