### PR TITLE
Added BYOS Hanami webhook format with JWT authentication

### DIFF
--- a/trmnl-ha/DOCS.md
+++ b/trmnl-ha/DOCS.md
@@ -271,6 +271,22 @@ Presets auto-configure viewport, rotation, dithering, and format.
 
 ---
 
+## Webhook Formats
+
+The add-on supports multiple webhook payload formats for different e-ink display backends:
+
+| Format | Use Case |
+|--------|----------|
+| **Raw** (default) | TRMNL devices, custom endpoints |
+| **BYOS Hanami** | Self-hosted [BYOS](https://github.com/usetrmnl/byos) servers |
+
+See **[Webhook Formats Guide](docs/webhook-formats.md)** for:
+- Detailed format specifications
+- JWT authentication setup for BYOS
+- How to add custom webhook formats
+
+---
+
 ## Troubleshooting
 
 ### Proxmox Users

--- a/trmnl-ha/README.md
+++ b/trmnl-ha/README.md
@@ -77,6 +77,7 @@ If running Home Assistant OS in Proxmox, set the VM host type to `host` for Chro
 | [API Reference](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#api-reference) | Screenshot endpoint parameters |
 | [Device Presets](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#device-presets) | Supported e-ink displays |
 | [Scheduled Captures](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#scheduled-captures) | Cron-based automation |
+| [Webhook Formats](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/docs/webhook-formats.md) | TRMNL, BYOS, and custom endpoints |
 | [Troubleshooting](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#troubleshooting) | Common issues and fixes |
 | [Local Development](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#local-development) | Development setup |
 

--- a/trmnl-ha/docs/webhook-formats.md
+++ b/trmnl-ha/docs/webhook-formats.md
@@ -1,0 +1,197 @@
+# Webhook Formats
+
+When uploading screenshots via webhooks, the add-on supports multiple payload formats to integrate with different e-ink display backends.
+
+## Supported Formats
+
+| Format | Content-Type | Use Case |
+|--------|--------------|----------|
+| **Raw** (default) | `image/png`, `image/jpeg`, `image/bmp` | Direct binary upload to TRMNL or custom endpoints |
+| **BYOS Hanami** | `application/json` | Self-hosted [BYOS](https://github.com/usetrmnl/byos) servers |
+
+---
+
+## Raw Format
+
+The default format sends the image binary directly as the request body. This is the simplest format and works with most webhook endpoints.
+
+**Request:**
+```http
+POST /your-webhook-endpoint
+Content-Type: image/png
+Authorization: Bearer <optional-token>
+
+<binary image data>
+```
+
+**When to use:** TRMNL devices, custom webhook endpoints, any service expecting raw image uploads.
+
+---
+
+## BYOS Hanami Format
+
+For self-hosted [BYOS (Build Your Own Server)](https://github.com/usetrmnl/byos) installations, this format wraps the image in a JSON payload with metadata.
+
+**Request:**
+```http
+POST /api/screens
+Content-Type: application/json
+Authorization: <jwt-access-token>
+
+{
+  "screen": {
+    "data": "<base64-encoded-image>",
+    "label": "Home Assistant",
+    "name": "ha-dashboard",
+    "model_id": "1"
+  }
+}
+```
+
+### Configuration Fields
+
+| Field | Description |
+|-------|-------------|
+| `label` | Display name shown in BYOS UI |
+| `name` | Unique screen identifier (slug format) |
+| `model_id` | BYOS device model ID (from your BYOS setup) |
+| `preprocessed` | Whether the image is already optimized for e-ink |
+
+### JWT Authentication
+
+BYOS requires JWT authentication. You can either:
+
+1. **Login via UI:** Enter your BYOS credentials in the schedule settings. The add-on exchanges them for tokens (credentials are NOT stored).
+2. **Manual tokens:** Paste your access and refresh tokens directly if you prefer not to enter credentials.
+
+Tokens auto-refresh when expired (25-minute validity, refreshed before 30-minute expiry).
+
+### 422 Error Handling
+
+If BYOS returns `422 Unprocessable Entity` (screen already exists), the add-on automatically:
+1. Lists existing screens via `GET /api/screens`
+2. Finds and deletes the screen with matching `model_id`
+3. Retries the upload
+
+---
+
+## Adding Custom Formats
+
+The webhook system uses a **Strategy Pattern** for extensibility. To add a new format:
+
+### 1. Define the Format Type
+
+Add your format to `types/domain.ts`:
+
+```typescript
+// Add to WebhookFormat union type
+export type WebhookFormat = 'raw' | 'byos-hanami' | 'your-format'
+
+// Add config interface if needed
+export interface YourFormatConfig {
+  apiKey: string
+  // ... other fields
+}
+```
+
+### 2. Create a Transformer
+
+Add a new file `lib/scheduler/your-format-transformer.ts` or add to `webhook-formats.ts`:
+
+```typescript
+import type { FormatTransformer, WebhookPayload } from './webhook-formats.js'
+import type { ImageFormat } from '../../types/domain.js'
+
+export class YourFormatTransformer implements FormatTransformer {
+  transform(
+    imageBuffer: Buffer,
+    format: ImageFormat,
+    config?: YourFormatConfig,
+  ): WebhookPayload {
+    // Transform the image buffer into your payload format
+    return {
+      body: JSON.stringify({
+        image: imageBuffer.toString('base64'),
+        // ... your format's structure
+      }),
+      contentType: 'application/json',
+    }
+  }
+}
+```
+
+### 3. Register the Transformer
+
+Update `getTransformer()` in `lib/scheduler/webhook-formats.ts`:
+
+```typescript
+export function getTransformer(
+  formatConfig?: WebhookFormatConfig | null,
+): FormatTransformer {
+  const format = formatConfig?.format ?? 'raw'
+
+  switch (format) {
+    case 'byos-hanami':
+      return new ByosHanamiFormatTransformer()
+    case 'your-format':
+      return new YourFormatTransformer()
+    default:
+      return new RawFormatTransformer()
+  }
+}
+```
+
+### 4. Add UI Controls (Optional)
+
+If your format needs configuration, add form fields in `html/js/ui-renderer.ts`:
+
+```typescript
+// In #renderWebhookFormatSection()
+if (format === 'your-format') {
+  html += `
+    <div class="form-group">
+      <label>API Key</label>
+      <input type="text" name="your_api_key" value="${config?.apiKey ?? ''}" />
+    </div>
+  `
+}
+```
+
+### 5. Write Tests
+
+Add tests in `tests/unit/webhook-formats.test.ts`:
+
+```typescript
+describe('YourFormatTransformer', () => {
+  it('transforms image to your format', () => {
+    const transformer = new YourFormatTransformer()
+    const result = transformer.transform(testBuffer, 'png', { apiKey: 'test' })
+
+    expect(result.contentType).toBe('application/json')
+    // ... verify payload structure
+  })
+})
+```
+
+---
+
+## Architecture Overview
+
+```
+Schedule Execution
+       ↓
+ScheduleExecutor.call()
+       ↓
+uploadToWebhook(options)
+       ↓
+getTransformer(webhookFormat)  ← Strategy selection
+       ↓
+transformer.transform(buffer, format, config)
+       ↓
+fetch(webhookUrl, { body, headers })
+```
+
+The transformer is responsible for:
+- Converting the image buffer to the target payload format
+- Setting the appropriate `Content-Type` header
+- Encoding data as needed (base64, multipart, etc.)

--- a/trmnl-ha/ha-trmnl/html/js/api-client.ts
+++ b/trmnl-ha/ha-trmnl/html/js/api-client.ts
@@ -194,3 +194,47 @@ export class FetchPreview {
     return response.blob()
   }
 }
+
+/** Response from BYOS login API */
+export interface ByosLoginResponse {
+  success: boolean
+  access_token?: string
+  refresh_token?: string
+  obtained_at?: number
+  error?: string
+}
+
+/**
+ * Authenticates with BYOS server and returns tokens.
+ * Credentials are NOT stored - only passed to server for authentication.
+ */
+export class ByosLogin {
+  baseUrl: string
+
+  constructor(baseUrl = './api/byos/login') {
+    this.baseUrl = baseUrl
+  }
+
+  async call(
+    webhookUrl: string,
+    login: string,
+    password: string,
+  ): Promise<ByosLoginResponse> {
+    const response = await fetch(this.baseUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ webhookUrl, login, password }),
+    })
+
+    const data = (await response.json()) as ByosLoginResponse
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: data.error ?? `HTTP ${response.status}: ${response.statusText}`,
+      }
+    }
+
+    return data
+  }
+}

--- a/trmnl-ha/ha-trmnl/lib/scheduler/byos-auth.ts
+++ b/trmnl-ha/ha-trmnl/lib/scheduler/byos-auth.ts
@@ -1,0 +1,149 @@
+/**
+ * BYOS Hanami JWT Authentication Manager
+ *
+ * Handles token refresh for BYOS API. Tokens are stored in schedule config,
+ * NOT credentials - user authenticates once via UI, tokens are saved.
+ *
+ * @module lib/scheduler/byos-auth
+ */
+
+import type { ByosAuthConfig } from '../../types/domain.js'
+import { webhookLogger } from '../logger.js'
+
+const log = webhookLogger()
+
+/** Token response from BYOS login/refresh endpoints */
+export interface TokenResponse {
+  access_token: string
+  refresh_token: string
+  success?: string
+}
+
+/** Token validity duration (25 min to refresh before 30 min expiry) */
+const ACCESS_TOKEN_VALIDITY_MS = 25 * 60 * 1000
+
+/**
+ * Extracts base URL from webhook URL.
+ * e.g., "https://example.com/api/screens" → "https://example.com"
+ */
+export function getBaseUrl(webhookUrl: string): string {
+  const url = new URL(webhookUrl)
+  return `${url.protocol}//${url.host}`
+}
+
+/**
+ * Checks if stored token is still valid (not expired).
+ */
+function isTokenValid(auth: ByosAuthConfig): boolean {
+  if (!auth.obtained_at || !auth.access_token) return false
+  const elapsed = Date.now() - auth.obtained_at
+  return elapsed < ACCESS_TOKEN_VALIDITY_MS
+}
+
+/**
+ * Performs login to get initial tokens.
+ * Called from UI only - credentials are NOT stored.
+ */
+export async function login(
+  baseUrl: string,
+  loginEmail: string,
+  password: string,
+): Promise<TokenResponse> {
+  const loginUrl = `${baseUrl}/login`
+  log.info`BYOS auth: logging in to ${baseUrl}`
+
+  const response = await fetch(loginUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ login: loginEmail, password }),
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(`BYOS login failed: ${response.status} ${text}`)
+  }
+
+  const data = (await response.json()) as TokenResponse
+  if (!data.access_token || !data.refresh_token) {
+    throw new Error('BYOS login response missing tokens')
+  }
+
+  log.info`BYOS auth: login successful`
+  return data
+}
+
+/**
+ * Refreshes access token using refresh token.
+ */
+async function refreshToken(
+  baseUrl: string,
+  auth: ByosAuthConfig,
+): Promise<TokenResponse> {
+  const refreshUrl = `${baseUrl}/api/jwt`
+  log.info`BYOS auth: refreshing token`
+
+  const response = await fetch(refreshUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: auth.access_token!,
+    },
+    body: JSON.stringify({ refresh_token: auth.refresh_token }),
+  })
+
+  if (!response.ok) {
+    log.warn`BYOS auth: refresh failed (${response.status})`
+    throw new Error(`BYOS token refresh failed: ${response.status}`)
+  }
+
+  const data = (await response.json()) as TokenResponse
+  if (!data.access_token || !data.refresh_token) {
+    throw new Error('BYOS refresh response missing tokens')
+  }
+
+  log.info`BYOS auth: token refreshed successfully`
+  return data
+}
+
+/**
+ * Gets a valid access token, refreshing if needed.
+ * Returns null if tokens are missing/expired and need re-authentication.
+ *
+ * @param webhookUrl - Full webhook URL (base URL is extracted)
+ * @param auth - Stored auth config with tokens
+ * @param onTokenRefresh - Callback to save new tokens (called on refresh)
+ * @returns Access token or null if re-auth needed
+ */
+export async function getValidAccessToken(
+  webhookUrl: string,
+  auth: ByosAuthConfig,
+  onTokenRefresh?: (newTokens: TokenResponse) => void,
+): Promise<string | null> {
+  // No tokens stored - need to authenticate
+  if (!auth.access_token || !auth.refresh_token) {
+    log.warn`BYOS auth: no tokens stored, authentication required`
+    return null
+  }
+
+  // Token still valid - use it
+  if (isTokenValid(auth)) {
+    return auth.access_token
+  }
+
+  // Token expired - try to refresh
+  try {
+    const baseUrl = getBaseUrl(webhookUrl)
+    const newTokens = await refreshToken(baseUrl, auth)
+
+    // Notify caller to save new tokens
+    if (onTokenRefresh) {
+      onTokenRefresh(newTokens)
+    }
+
+    return newTokens.access_token
+  } catch (err) {
+    // Refresh failed - user needs to re-authenticate
+    log.error`BYOS auth: refresh failed, re-authentication required: ${(err as Error).message}`
+    return null
+  }
+}

--- a/trmnl-ha/ha-trmnl/lib/scheduler/schedule-executor.ts
+++ b/trmnl-ha/ha-trmnl/lib/scheduler/schedule-executor.ts
@@ -96,12 +96,12 @@ export class ScheduleExecutor {
     const savedPath = await this.#saveAndCleanup(
       schedule,
       imageBuffer,
-      params.format
+      params.format,
     )
     const webhook = await this.#uploadIfConfigured(
       schedule,
       imageBuffer,
-      params.format
+      params.format,
     )
     return { success: true, savedPath, webhook }
   }
@@ -110,7 +110,7 @@ export class ScheduleExecutor {
   async #saveAndCleanup(
     schedule: Schedule,
     imageBuffer: Buffer,
-    format: string
+    format: string,
   ): Promise<string> {
     const { outputPath } = saveScreenshot({
       outputDir: this.#outputDir,
@@ -138,7 +138,7 @@ export class ScheduleExecutor {
   async #uploadIfConfigured(
     schedule: Schedule,
     imageBuffer: Buffer,
-    format: string
+    format: string,
   ): Promise<WebhookResult | undefined> {
     if (!schedule.webhook_url) return undefined
 
@@ -150,6 +150,7 @@ export class ScheduleExecutor {
         webhookHeaders: schedule.webhook_headers,
         imageBuffer,
         format: format as 'png' | 'jpeg' | 'bmp',
+        webhookFormat: schedule.webhook_format,
       })
 
       log.info`Schedule "${schedule.name}" webhook success: ${result.status} ${result.statusText}`

--- a/trmnl-ha/ha-trmnl/lib/scheduler/webhook-delivery.ts
+++ b/trmnl-ha/ha-trmnl/lib/scheduler/webhook-delivery.ts
@@ -8,17 +8,86 @@
  */
 
 import { SCHEDULER_RESPONSE_BODY_TRUNCATE_LENGTH } from '../../const.js'
-import type { ImageFormat } from '../../types/domain.js'
+import type { ImageFormat, WebhookFormatConfig } from '../../types/domain.js'
 import { webhookLogger } from '../logger.js'
+import { getTransformer } from './webhook-formats.js'
+import { getValidAccessToken, getBaseUrl } from './byos-auth.js'
 
 const log = webhookLogger()
 
-/** MIME type mapping */
-const CONTENT_TYPES: Record<string, string> = {
-  jpeg: 'image/jpeg',
-  jpg: 'image/jpeg',
-  bmp: 'image/bmp',
-  png: 'image/png',
+/** Screen object from BYOS API */
+interface ByosScreen {
+  id: number
+  model_id: number
+  label: string
+  name: string
+  [key: string]: unknown
+}
+
+/** BYOS API response wrapper */
+interface ByosScreensResponse {
+  data: ByosScreen[]
+}
+
+/**
+ * Deletes an existing BYOS screen by model_id.
+ * Used to handle 422 errors when screen already exists.
+ *
+ * @param webhookUrl - The webhook URL (used to derive base URL)
+ * @param modelId - The model_id to search for (as string, compared to API's number)
+ * @param authToken - Bearer token for authentication
+ * @returns true if screen was found and deleted, false otherwise
+ */
+async function deleteExistingByosScreen(
+  webhookUrl: string,
+  modelId: string,
+  authToken: string,
+): Promise<boolean> {
+  const baseUrl = getBaseUrl(webhookUrl)
+  const screensUrl = `${baseUrl}/api/screens`
+
+  try {
+    // GET /api/screens to list all screens
+    const listResponse = await fetch(screensUrl, {
+      method: 'GET',
+      headers: { Authorization: authToken },
+    })
+
+    if (!listResponse.ok) {
+      log.error`Failed to list screens: ${listResponse.status} ${listResponse.statusText}`
+      return false
+    }
+
+    const response = (await listResponse.json()) as ByosScreensResponse
+    const screens = response.data
+
+    // Find screen with matching model_id (API returns number, we store string)
+    const targetModelId = parseInt(modelId, 10)
+    const existingScreen = screens.find((s) => s.model_id === targetModelId)
+    if (!existingScreen) {
+      log.debug`No existing screen found with model_id: ${modelId}`
+      return false
+    }
+
+    log.info`Found existing screen id=${existingScreen.id} with model_id=${modelId}, deleting...`
+
+    // DELETE /api/screens/:id
+    const deleteResponse = await fetch(`${screensUrl}/${existingScreen.id}`, {
+      method: 'DELETE',
+      headers: { Authorization: authToken },
+    })
+
+    if (!deleteResponse.ok) {
+      log.error`Failed to delete screen: ${deleteResponse.status} ${deleteResponse.statusText}`
+      return false
+    }
+
+    log.info`Successfully deleted screen id=${existingScreen.id}`
+    return true
+  } catch (err) {
+    log.error`Error during screen deletion: ${(err as Error).message}`
+    return false
+  }
 }
 
 /** Options for webhook upload */
@@ -27,6 +96,8 @@ export interface WebhookDeliveryOptions {
   webhookHeaders?: Record<string, string>
   imageBuffer: Buffer
   format: ImageFormat
+  /** Webhook payload format (null/undefined = 'raw' for backward compat) */
+  webhookFormat?: WebhookFormatConfig | null
 }
 
 /** Result from webhook upload */
@@ -44,17 +115,56 @@ export interface WebhookDeliveryResult {
  * @throws Error on HTTP errors (4xx, 5xx) or network failures
  */
 export async function uploadToWebhook(
-  options: WebhookDeliveryOptions
+  options: WebhookDeliveryOptions,
 ): Promise<WebhookDeliveryResult> {
-  const { webhookUrl, webhookHeaders = {}, imageBuffer, format } = options
-  const contentType = CONTENT_TYPES[format] || 'image/png'
+  const {
+    webhookUrl,
+    webhookHeaders = {},
+    imageBuffer,
+    format,
+    webhookFormat,
+  } = options
 
-  log.info`Sending webhook: ${webhookUrl} (${contentType}, ${imageBuffer.length} bytes)`
+  // Get transformer and build payload
+  const transformer = getTransformer(webhookFormat)
+  const byosConfig =
+    webhookFormat?.format === 'byos-hanami'
+      ? webhookFormat.byosConfig
+      : undefined
+  const { body, contentType } = transformer.transform(
+    imageBuffer,
+    format,
+    byosConfig,
+  )
+
+  log.info`Sending webhook: ${webhookUrl} (${contentType}, ${imageBuffer.length} bytes, format: ${webhookFormat?.format ?? 'raw'})`
+
+  // Convert body to appropriate type for fetch API
+  // String for JSON payloads, Uint8Array for binary (Buffer isn't directly supported)
+  const fetchBody: BodyInit =
+    typeof body === 'string' ? body : new Uint8Array(body)
+
+  // Build headers with optional BYOS JWT auth
+  const headers: Record<string, string> = {
+    ...webhookHeaders,
+    'Content-Type': contentType,
+  }
+
+  // Handle BYOS JWT authentication
+  if (byosConfig?.auth?.enabled && byosConfig.auth.access_token) {
+    const accessToken = await getValidAccessToken(webhookUrl, byosConfig.auth)
+    if (accessToken) {
+      headers['Authorization'] = accessToken
+      log.debug`BYOS auth: using JWT token`
+    } else {
+      log.warn`BYOS auth: no valid token, request may fail`
+    }
+  }
 
   const response = await fetch(webhookUrl, {
     method: 'POST',
-    headers: { ...webhookHeaders, 'Content-Type': contentType },
-    body: new Uint8Array(imageBuffer),
+    headers,
+    body: fetchBody,
   })
 
   const responseText = await response.text()
@@ -62,12 +172,40 @@ export async function uploadToWebhook(
   if (!response.ok) {
     log.error`Webhook failed: ${response.status} ${response.statusText}`
 
+    // Handle 422 (Unprocessable Entity) - likely screen already exists in BYOS
+    // Try to delete the existing screen and retry
+    if (response.status === 422 && byosConfig && headers['Authorization']) {
+      log.info`Got 422, attempting to delete existing screen and retry...`
+      const deleted = await deleteExistingByosScreen(
+        webhookUrl,
+        byosConfig.model_id,
+        headers['Authorization'],
+      )
+      if (deleted) {
+        log.info`Deleted existing screen, retrying upload...`
+        const retryResponse = await fetch(webhookUrl, {
+          method: 'POST',
+          headers,
+          body: fetchBody,
+        })
+        if (retryResponse.ok) {
+          log.info`Retry successful: ${retryResponse.status} ${retryResponse.statusText}`
+          return {
+            success: true,
+            status: retryResponse.status,
+            statusText: retryResponse.statusText,
+          }
+        }
+        log.error`Retry also failed: ${retryResponse.status} ${retryResponse.statusText}`
+      }
+    }
+
     // Extract error message from response body for better UI feedback
     let errorDetail = ''
     if (responseText) {
       const truncated = responseText.substring(
         0,
-        SCHEDULER_RESPONSE_BODY_TRUNCATE_LENGTH
+        SCHEDULER_RESPONSE_BODY_TRUNCATE_LENGTH,
       )
       log.error`Response body: ${truncated}`
 
@@ -90,7 +228,9 @@ export async function uploadToWebhook(
       }
     }
 
-    throw new Error(`HTTP ${response.status}: ${response.statusText}${errorDetail}`)
+    throw new Error(
+      `HTTP ${response.status}: ${response.statusText}${errorDetail}`,
+    )
   }
 
   log.info`Webhook success: ${response.status} ${response.statusText}`
@@ -98,5 +238,9 @@ export async function uploadToWebhook(
     log.debug`Response body: ${responseText.substring(0, SCHEDULER_RESPONSE_BODY_TRUNCATE_LENGTH)}`
   }
 
-  return { success: true, status: response.status, statusText: response.statusText }
+  return {
+    success: true,
+    status: response.status,
+    statusText: response.statusText,
+  }
 }

--- a/trmnl-ha/ha-trmnl/lib/scheduler/webhook-formats.ts
+++ b/trmnl-ha/ha-trmnl/lib/scheduler/webhook-formats.ts
@@ -1,0 +1,132 @@
+/**
+ * Webhook Format Transformers - Strategy Pattern for Payload Formats
+ *
+ * Transforms screenshot image data into format-specific webhook payloads.
+ * Each format (raw, BYOS Hanami, etc.) has its own transformer that knows
+ * how to structure the HTTP payload correctly.
+ *
+ * @module lib/scheduler/webhook-formats
+ */
+
+import type {
+  ImageFormat,
+  WebhookFormatConfig,
+  ByosHanamiConfig,
+} from '../../types/domain.js'
+
+/** MIME type mapping for image formats */
+const CONTENT_TYPES: Record<ImageFormat, string> = {
+  png: 'image/png',
+  jpeg: 'image/jpeg',
+  bmp: 'image/bmp',
+}
+
+/** Transformed webhook payload ready for HTTP POST */
+export interface WebhookPayload {
+  /** Request body (Buffer for binary, string for JSON) */
+  body: Buffer | string
+  /** Content-Type header value */
+  contentType: string
+}
+
+/** Strategy interface for webhook format transformers */
+export interface FormatTransformer {
+  /**
+   * Transforms image buffer into format-specific webhook payload.
+   *
+   * @param imageBuffer - Raw image data
+   * @param format - Image format (png, jpeg, bmp)
+   * @param config - Optional format-specific configuration
+   * @returns Payload with body and content type
+   */
+  transform(
+    imageBuffer: Buffer,
+    format: ImageFormat,
+    config?: unknown,
+  ): WebhookPayload
+}
+
+/**
+ * Raw format transformer - sends binary image data directly.
+ * This is the current/default behavior.
+ */
+export class RawFormatTransformer implements FormatTransformer {
+  transform(imageBuffer: Buffer, format: ImageFormat): WebhookPayload {
+    return {
+      body: imageBuffer,
+      contentType: CONTENT_TYPES[format] ?? 'image/png',
+    }
+  }
+}
+
+/**
+ * BYOS Hanami API format transformer.
+ * Wraps image in JSON with base64 encoding and metadata.
+ *
+ * BYOS API expects:
+ * ```
+ * POST /api/screens
+ * Content-Type: application/json
+ * {
+ *   "screen": {
+ *     "data": "<base64-encoded-image>",
+ *     "label": "Home Assistant",
+ *     "name": "ha-dashboard",
+ *     "model_id": "1",
+ *     "file_name": "ha-dashboard.png"
+ *   }
+ * }
+ * ```
+ */
+export class ByosHanamiFormatTransformer implements FormatTransformer {
+  transform(
+    imageBuffer: Buffer,
+    format: ImageFormat,
+    config?: ByosHanamiConfig,
+  ): WebhookPayload {
+    if (!config) {
+      throw new Error(
+        'BYOS Hanami format requires config with label, name, and model_id',
+      )
+    }
+
+    const base64Data = imageBuffer.toString('base64')
+    const fileName = `${config.name}.${format}`
+
+    const payload = {
+      screen: {
+        data: base64Data,
+        label: config.label,
+        name: config.name,
+        model_id: config.model_id,
+        file_name: fileName,
+      },
+    }
+
+    return {
+      body: JSON.stringify(payload),
+      contentType: 'application/json',
+    }
+  }
+}
+
+/**
+ * Factory function to get the appropriate transformer for a webhook format.
+ *
+ * @param formatConfig - Optional format configuration (null/undefined = raw)
+ * @returns Format transformer instance
+ */
+export function getTransformer(
+  formatConfig?: WebhookFormatConfig | null,
+): FormatTransformer {
+  if (!formatConfig || formatConfig.format === 'raw') {
+    return new RawFormatTransformer()
+  }
+
+  if (formatConfig.format === 'byos-hanami') {
+    return new ByosHanamiFormatTransformer()
+  }
+
+  // Fallback to raw for unknown formats (defensive)
+  return new RawFormatTransformer()
+}

--- a/trmnl-ha/ha-trmnl/tests/unit/webhook-formats.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/webhook-formats.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for Webhook Format Transformers
+ *
+ * Tests the strategy pattern implementation for different webhook payload formats.
+ *
+ * @module tests/unit/webhook-formats
+ */
+
+import { describe, it, expect } from 'bun:test'
+import {
+  RawFormatTransformer,
+  ByosHanamiFormatTransformer,
+  getTransformer,
+} from '../../lib/scheduler/webhook-formats.js'
+import type { WebhookFormatConfig } from '../../types/domain.js'
+
+describe('RawFormatTransformer', () => {
+  const transformer = new RawFormatTransformer()
+
+  it('returns Buffer body with image buffer contents', () => {
+    const imageBuffer = Buffer.from('test image data')
+    const result = transformer.transform(imageBuffer, 'png')
+
+    expect(result.body).toBeInstanceOf(Buffer)
+    expect((result.body as Buffer).toString()).toBe('test image data')
+  })
+
+  it('sets correct Content-Type for PNG', () => {
+    const imageBuffer = Buffer.from('test')
+    const result = transformer.transform(imageBuffer, 'png')
+
+    expect(result.contentType).toBe('image/png')
+  })
+
+  it('sets correct Content-Type for JPEG', () => {
+    const imageBuffer = Buffer.from('test')
+    const result = transformer.transform(imageBuffer, 'jpeg')
+
+    expect(result.contentType).toBe('image/jpeg')
+  })
+
+  it('sets correct Content-Type for BMP', () => {
+    const imageBuffer = Buffer.from('test')
+    const result = transformer.transform(imageBuffer, 'bmp')
+
+    expect(result.contentType).toBe('image/bmp')
+  })
+})
+
+describe('ByosHanamiFormatTransformer', () => {
+  const transformer = new ByosHanamiFormatTransformer()
+  const validConfig = {
+    label: 'Home Assistant',
+    name: 'ha-dashboard',
+    model_id: '1',
+    preprocessed: true,
+  }
+
+  it('returns JSON string body', () => {
+    const imageBuffer = Buffer.from('test image data')
+    const result = transformer.transform(imageBuffer, 'png', validConfig)
+
+    expect(typeof result.body).toBe('string')
+    // Should be valid JSON
+    expect(() => JSON.parse(result.body as string)).not.toThrow()
+  })
+
+  it('sets Content-Type to application/json', () => {
+    const imageBuffer = Buffer.from('test')
+    const result = transformer.transform(imageBuffer, 'png', validConfig)
+
+    expect(result.contentType).toBe('application/json')
+  })
+
+  it('base64 encodes image data correctly', () => {
+    const imageBuffer = Buffer.from('test image data')
+    const result = transformer.transform(imageBuffer, 'png', validConfig)
+    const payload = JSON.parse(result.body as string)
+
+    // Decode base64 and verify
+    const decoded = Buffer.from(payload.screen.data, 'base64').toString()
+    expect(decoded).toBe('test image data')
+  })
+
+  it('includes all required BYOS fields', () => {
+    const imageBuffer = Buffer.from('test')
+    const result = transformer.transform(imageBuffer, 'png', validConfig)
+    const payload = JSON.parse(result.body as string)
+
+    expect(payload.screen).toBeDefined()
+    expect(payload.screen.data).toBeDefined()
+    expect(payload.screen.label).toBe('Home Assistant')
+    expect(payload.screen.name).toBe('ha-dashboard')
+    expect(payload.screen.model_id).toBe('1')
+    expect(payload.screen.file_name).toBe('ha-dashboard.png')
+  })
+
+  it('sets correct file_name extension for JPEG', () => {
+    const imageBuffer = Buffer.from('test')
+    const result = transformer.transform(imageBuffer, 'jpeg', validConfig)
+    const payload = JSON.parse(result.body as string)
+
+    expect(payload.screen.file_name).toBe('ha-dashboard.jpeg')
+  })
+
+  it('sets correct file_name extension for BMP', () => {
+    const imageBuffer = Buffer.from('test')
+    const result = transformer.transform(imageBuffer, 'bmp', validConfig)
+    const payload = JSON.parse(result.body as string)
+
+    expect(payload.screen.file_name).toBe('ha-dashboard.bmp')
+  })
+
+  it('throws error when config is missing', () => {
+    const imageBuffer = Buffer.from('test')
+
+    expect(() => transformer.transform(imageBuffer, 'png')).toThrow(
+      'BYOS Hanami format requires config with label, name, and model_id',
+    )
+  })
+})
+
+describe('getTransformer factory', () => {
+  it('returns RawFormatTransformer for undefined format', () => {
+    const transformer = getTransformer(undefined)
+
+    expect(transformer).toBeInstanceOf(RawFormatTransformer)
+  })
+
+  it('returns RawFormatTransformer for raw format', () => {
+    const config: WebhookFormatConfig = { format: 'raw' }
+    const transformer = getTransformer(config)
+
+    expect(transformer).toBeInstanceOf(RawFormatTransformer)
+  })
+
+  it('returns ByosHanamiFormatTransformer for byos-hanami format', () => {
+    const config: WebhookFormatConfig = {
+      format: 'byos-hanami',
+      byosConfig: {
+        label: 'Test',
+        name: 'test',
+        model_id: '1',
+        preprocessed: true,
+      },
+    }
+    const transformer = getTransformer(config)
+
+    expect(transformer).toBeInstanceOf(ByosHanamiFormatTransformer)
+  })
+
+  it('returns RawFormatTransformer for unknown format (defensive fallback)', () => {
+    // Force unknown format via type assertion (simulates future format or data corruption)
+    const config = {
+      format: 'unknown-format',
+    } as unknown as WebhookFormatConfig
+    const transformer = getTransformer(config)
+
+    expect(transformer).toBeInstanceOf(RawFormatTransformer)
+  })
+})

--- a/trmnl-ha/ha-trmnl/types/domain.ts
+++ b/trmnl-ha/ha-trmnl/types/domain.ts
@@ -129,6 +129,46 @@ export interface ScreenshotParams {
 }
 
 // =============================================================================
+// WEBHOOK FORMATS
+// =============================================================================
+
+/** Supported webhook payload formats */
+export type WebhookFormat = 'raw' | 'byos-hanami'
+
+/** BYOS Hanami API configuration */
+export interface ByosHanamiConfig {
+  /** Display label shown in BYOS UI */
+  label: string
+  /** Unique screen identifier */
+  name: string
+  /** BYOS model ID */
+  model_id: string
+  /** Whether the screen has been preprocessed */
+  preprocessed: boolean
+  /** JWT authentication settings */
+  auth?: ByosAuthConfig
+}
+
+/** BYOS JWT authentication configuration (tokens only - no credentials stored) */
+export interface ByosAuthConfig {
+  /** Enable JWT authentication */
+  enabled: boolean
+  /** JWT access token (short-lived, ~30 min) */
+  access_token?: string
+  /** JWT refresh token (long-lived, ~14 days) */
+  refresh_token?: string
+  /** Timestamp when tokens were obtained */
+  obtained_at?: number
+}
+
+/** Webhook format configuration */
+export interface WebhookFormatConfig {
+  format: WebhookFormat
+  /** Required when format is 'byos-hanami' */
+  byosConfig?: ByosHanamiConfig
+}
+
+// =============================================================================
 // SCHEDULE
 // =============================================================================
 
@@ -155,6 +195,9 @@ export interface Schedule {
 
   /** Custom headers for webhook requests */
   webhook_headers?: Record<string, string>
+
+  /** Webhook payload format configuration (null/undefined = 'raw' for backward compat) */
+  webhook_format?: WebhookFormatConfig | null
 
   /** Whether to use Home Assistant mode (true) or generic URL mode (false) */
   ha_mode: boolean
@@ -302,8 +345,9 @@ export const isColorPalette = (c: PaletteConfig): c is ColorPaletteConfig =>
   'colors' in c
 
 /** Type guard: is this a grayscale palette config? */
-export const isGrayscalePalette = (c: PaletteConfig): c is GrayscalePaletteConfig =>
-  'levels' in c
+export const isGrayscalePalette = (
+  c: PaletteConfig,
+): c is GrayscalePaletteConfig => 'levels' in c
 
 /** Color palette definitions (hex color arrays) - derived from PALETTES */
 export type ColorPaletteDefinition = Record<ColorPalette, string[]>


### PR DESCRIPTION
Necessary to support self-hosted TRMNL displays using the BYOS Hanami API. Users can now select between raw image uploads and JSON-wrapped base64 payloads compatible with the /api/screens endpoint.

Implements:
- Strategy pattern for webhook payload transformation (raw vs. byos-hanami)
- JWT authentication flow with token refresh (credentials never stored)
- 422 error handling with automatic screen deletion and retry
- UI for BYOS configuration including login and manual token entry