### PR TITLE
Terminus support improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Send Home Assistant dashboard screenshots to your TRMNL e-ink display with advan
 
 - **E-ink optimized dithering** - Floyd-Steinberg and Ordered algorithms for crisp e-paper rendering
 - **TRMNL webhook integration** - Automatic dashboard uploads to TRMNL devices
+- **Fetch URL (pull mode)** - Direct URL for on-demand screenshots, works with ESPHome and custom e-ink setups
 - **Scheduled captures** - Cron-based automation with Web UI management
 - **Device presets** - Pre-configured settings for 24+ popular e-ink displays
 - **Crash recovery** - Automatic browser recovery and process supervision
@@ -75,8 +76,10 @@ If running Home Assistant OS in Proxmox, set the VM host type to `host` for Chro
 | [Configuration](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#configuration) | Required and optional settings |
 | [Web UI](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#web-ui) | Using the web interface |
 | [API Reference](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#api-reference) | Screenshot endpoint parameters |
+| [Fetch URL (Pull Mode)](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#fetch-url-pull-mode) | On-demand screenshots via direct URL |
 | [Device Presets](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#device-presets) | Supported e-ink displays |
 | [Scheduled Captures](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#scheduled-captures) | Cron-based automation |
+| [Webhook Formats](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/docs/webhook-formats.md) | TRMNL, BYOS, and custom endpoints |
 | [Troubleshooting](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#troubleshooting) | Common issues and fixes |
 | [Local Development](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#local-development) | Development setup |
 

--- a/trmnl-ha/README.md
+++ b/trmnl-ha/README.md
@@ -14,6 +14,7 @@ Send Home Assistant dashboard screenshots to your TRMNL e-ink display with advan
 
 - **E-ink optimized dithering** - Floyd-Steinberg and Ordered algorithms for crisp e-paper rendering
 - **TRMNL webhook integration** - Automatic dashboard uploads to TRMNL devices
+- **Fetch URL (pull mode)** - Direct URL for on-demand screenshots, works with ESPHome and custom e-ink setups
 - **Scheduled captures** - Cron-based automation with Web UI management
 - **Device presets** - Pre-configured settings for 24+ popular e-ink displays
 - **Crash recovery** - Automatic browser recovery and process supervision
@@ -46,7 +47,7 @@ docker run -d --name trmnl-ha \
   -e ACCESS_TOKEN=your_token_here \
   -p 10000:10000 \
   -v ./trmnl-data:/data \
-  ghcr.io/usetrmnl/trmnl-ha-amd64:latest
+  ghcr.io/usetrmnl/trmnl-ha-amd64:latest # ARM64 (Pi 4/5, Apple Silicon): ghcr.io/usetrmnl/trmnl-ha-aarch64:latest
 ```
 
 > **Note:** Replace `YOUR_HOST_IP` with your machine's IP (e.g., `192.168.1.100`). Container names like `homeassistant` won't work since HA uses host networking.
@@ -75,6 +76,7 @@ If running Home Assistant OS in Proxmox, set the VM host type to `host` for Chro
 | [Configuration](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#configuration) | Required and optional settings |
 | [Web UI](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#web-ui) | Using the web interface |
 | [API Reference](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#api-reference) | Screenshot endpoint parameters |
+| [Fetch URL (Pull Mode)](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#fetch-url-pull-mode) | On-demand screenshots via direct URL |
 | [Device Presets](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#device-presets) | Supported e-ink displays |
 | [Scheduled Captures](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#scheduled-captures) | Cron-based automation |
 | [Webhook Formats](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/docs/webhook-formats.md) | TRMNL, BYOS, and custom endpoints |

--- a/trmnl-ha/config.yaml
+++ b/trmnl-ha/config.yaml
@@ -16,6 +16,7 @@ arch:
 stage: stable
 
 # Enable ingress for sidebar integration
+# NOTE: ingress_port must match DEFAULT_SERVER_PORT in const.ts
 ingress: true
 ingress_port: 10000
 ingress_stream: false
@@ -26,9 +27,9 @@ panel_title: "TRMNL HA"
 
 # Keep ports for backward compatibility (optional direct access)
 ports:
-  10000/tcp: null
+  10000/tcp: 10000
 ports_description:
-  10000/tcp: "Web UI (use ingress instead)"
+  10000/tcp: "Web UI and API (direct access)"
 
 # Configuration options
 options:
@@ -37,6 +38,7 @@ options:
   timezone: ""
   keep_browser_open: false
   debug_logging: false
+  server_port: 10000
 
 # Schema for options validation
 schema:
@@ -45,6 +47,7 @@ schema:
   timezone: str?
   keep_browser_open: bool?
   debug_logging: bool?
+  server_port: "int(1024,65535)?"
 
 # Exclude regeneratable data from HA backups
 backup_exclude:

--- a/trmnl-ha/ha-trmnl/const.ts
+++ b/trmnl-ha/ha-trmnl/const.ts
@@ -130,6 +130,10 @@ const options: Options = {
     process.env['DEBUG_LOGGING'] !== undefined
       ? process.env['DEBUG_LOGGING'] === 'true'
       : fileOptions.debug_logging,
+  server_port:
+    process.env['SERVER_PORT'] !== undefined
+      ? parseInt(process.env['SERVER_PORT'], 10)
+      : fileOptions.server_port,
 }
 
 // Log configuration source for debugging
@@ -278,9 +282,29 @@ export const debugLogging: boolean = options.debug_logging ?? true
 // =============================================================================
 
 /**
- * HTTP server port
+ * Default HTTP server port (must match ingress_port in config.yaml for add-on mode)
  */
-export const SERVER_PORT: number = 10000
+const DEFAULT_SERVER_PORT = 10000
+
+/**
+ * HTTP server port
+ * - Add-on mode: Fixed at 10000 (required for HA ingress/sidebar)
+ * - Standalone mode: Configurable via server_port option or SERVER_PORT env var
+ */
+export const SERVER_PORT: number = isAddOn
+  ? DEFAULT_SERVER_PORT
+  : (options.server_port ?? DEFAULT_SERVER_PORT)
+
+// Warn if add-on user tried to configure a different port
+if (
+  isAddOn &&
+  options.server_port &&
+  options.server_port !== DEFAULT_SERVER_PORT
+) {
+  console.warn(
+    `[Config] ⚠️ server_port=${options.server_port} ignored in add-on mode (must be ${DEFAULT_SERVER_PORT} for HA ingress)`,
+  )
+}
 
 /**
  * Browser idle timeout before cleanup (milliseconds)

--- a/trmnl-ha/ha-trmnl/html/js/app.ts
+++ b/trmnl-ha/ha-trmnl/html/js/app.ts
@@ -676,6 +676,39 @@ class App {
   }
 
   // =============================================================================
+  // FETCH URL
+  // =============================================================================
+
+  /**
+   * Copies the fetch URL (with full origin) to clipboard.
+   */
+  async copyFetchUrl(): Promise<void> {
+    const input = document.getElementById(
+      's_fetch_url',
+    ) as HTMLInputElement | null
+    if (!input) return
+
+    const fullUrl = `${window.location.origin}${input.value}`
+
+    try {
+      await navigator.clipboard.writeText(fullUrl)
+      // Brief visual feedback
+      const copyBtn = input.nextElementSibling as HTMLButtonElement | null
+      if (copyBtn) {
+        const original = copyBtn.textContent
+        copyBtn.textContent = 'Copied!'
+        setTimeout(() => {
+          copyBtn.textContent = original
+        }, 1500)
+      }
+    } catch {
+      // Fallback: select the text for manual copy
+      input.value = fullUrl
+      input.select()
+    }
+  }
+
+  // =============================================================================
   // HA MODE TOGGLE
   // =============================================================================
 

--- a/trmnl-ha/ha-trmnl/html/js/ui-renderer.ts
+++ b/trmnl-ha/ha-trmnl/html/js/ui-renderer.ts
@@ -17,6 +17,8 @@
 
 import type { Schedule } from '../../types/domain.js'
 import type { PaletteOption } from './palette-options.js'
+import { buildScreenshotParams } from '../shared/build-screenshot-params.js'
+import { resolveScreenshotTarget } from '../shared/screenshot-target.js'
 
 /**
  * Renders the tab bar showing all schedules as clickable tabs.
@@ -141,6 +143,7 @@ export class RenderScheduleContent {
       : ''
 
     return `
+      ${this.#renderFetchUrl()}
       <div class="border-b pb-4">
         <h3 class="text-lg font-semibold mb-3" style="color: var(--primary-dark)">Schedule</h3>
         <div class="space-y-3">
@@ -208,6 +211,44 @@ export class RenderScheduleContent {
 
           ${this.#renderWebhookFormatSettings()}
         </div>
+      </div>
+    `
+  }
+
+  #renderFetchUrl(): string {
+    const s = this.schedule
+    const target = resolveScreenshotTarget(s)
+    const params = buildScreenshotParams(s)
+
+    // Build the full fetch URL
+    // For generic mode, add the url param
+    if (target.fullUrl) {
+      params.append('url', target.fullUrl)
+    }
+
+    const path = target.isHAMode ? target.path : '/'
+    const queryString = params.toString()
+    const fetchPath = queryString ? `${path}?${queryString}` : path
+
+    return `
+      <div class="mt-3 p-3 rounded-md" style="background-color: #f0f9ff; border: 1px solid #bae6fd">
+        <label class="block text-sm font-medium text-gray-700 mb-1">Fetch URL</label>
+        <div class="flex gap-2">
+          <input type="text" id="s_fetch_url" readonly
+            value="${fetchPath}"
+            class="w-full px-3 py-2 border rounded-md bg-white font-mono text-xs"
+            style="border-color: #93c5fd"
+            title="GET this URL to receive a screenshot with the current settings" />
+          <button onclick="window.app.copyFetchUrl()"
+            class="px-3 py-2 text-sm border-2 rounded-md transition hover:bg-gray-50 whitespace-nowrap"
+            style="border-color: var(--primary); color: var(--primary)"
+            title="Copy full URL to clipboard">
+            Copy
+          </button>
+        </div>
+        <p class="text-xs text-gray-500 mt-1">
+          Pull mode: any device can GET this URL to receive the screenshot image on demand. This URL is dynamically updated based on the settings below so the preview pane can be use to configure this URL.
+        </p>
       </div>
     `
   }

--- a/trmnl-ha/ha-trmnl/lib/config-helpers.ts
+++ b/trmnl-ha/ha-trmnl/lib/config-helpers.ts
@@ -17,6 +17,7 @@ export interface Options {
   chromium_executable?: string
   keep_browser_open?: boolean
   debug_logging?: boolean
+  server_port?: number
 }
 
 /**

--- a/trmnl-ha/ha-trmnl/main.ts
+++ b/trmnl-ha/ha-trmnl/main.ts
@@ -26,6 +26,7 @@ import {
   BROWSER_TIMEOUT,
   MAX_SCREENSHOTS_BEFORE_RESTART,
   MAX_NEXT_REQUESTS,
+  SERVER_PORT,
 } from './const.js'
 import {
   CannotOpenPageError,
@@ -499,17 +500,16 @@ const scheduler = new Scheduler((params) =>
 
 requestHandler.router.setScheduler(scheduler)
 
-const port = 10000
 const server: Server = http.createServer((request, response) =>
   requestHandler.handleRequest(request, response)
 )
-server.listen(port)
+server.listen(SERVER_PORT)
 
 scheduler.start()
 
 const serverUrl = isAddOn
-  ? `http://homeassistant.local:${port}`
-  : `http://localhost:${port}`
+  ? `http://homeassistant.local:${SERVER_PORT}`
+  : `http://localhost:${SERVER_PORT}`
 log.info`Server started at ${serverUrl}`
 log.info`Scheduler is running`
 

--- a/trmnl-ha/ha-trmnl/options-dev.json.example
+++ b/trmnl-ha/ha-trmnl/options-dev.json.example
@@ -5,5 +5,6 @@
   "access_token": "",
 
   "keep_browser_open": true,
-  "chromium_executable": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+  "chromium_executable": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  "server_port": 10000
 }


### PR DESCRIPTION
## Summary

- **Fetch URL feature** for pull-mode integration with ESPHome and other HTTP clients
- **Optimized BYOS 422 handling** using PATCH instead of delete-and-recreate
- **Configurable server port** for standalone mode deployments

## Changes

### Fetch URL for Pull-Mode Integration
Adds a direct, copyable URL for on-demand screenshot retrieval. ESPHome devices, cron jobs, and other HTTP clients can now GET this URL to receive processed screenshots with all schedule settings applied.

The URL is dynamically computed from the current schedule configuration and displayed in the Web UI with a copy button.

### Improved BYOS 422 Handling
Reduces API calls and eliminates the race condition window where the screen is briefly missing. When a 422 (screen exists) error occurs, we now find the existing screen by `model_id` and PATCH it directly.

**Before:** `POST (422) → GET → DELETE → POST` (3-4 calls)
**After:** `POST (422) → GET → PATCH` (2 calls)

### Configurable Server Port
Standalone users can now configure the server port via `server_port` option or `SERVER_PORT` environment variable. In add-on mode, the port remains fixed at 10000 (required for HA ingress/sidebar integration).

---

🤖 Generated with [Claude Code](https://claude.ai/code)