### PR TITLE
Fixed flaky CI tests caused by mock.module pollution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,36 @@ jobs:
           key: bun-${{ runner.os }}-${{ hashFiles('trmnl-ha/ha-trmnl/bun.lock') }}
           restore-keys: bun-${{ runner.os }}-
 
-      - name: Install ImageMagick
-        run: sudo apt-get update && sudo apt-get install -y imagemagick
+      - name: Install ImageMagick 7 (Q16-HDRI)
+        run: |
+          # Start a container from the same IM7 image used in production
+          docker create --name im7 --entrypoint "" \
+            dpokidov/imagemagick:7.1.1-47-bookworm tail -f /dev/null
+          docker start im7
+
+          # Copy IM7 binary, libraries, and config via docker cp
+          sudo docker cp im7:/usr/local/bin/magick /usr/local/bin/
+          sudo docker cp im7:/usr/local/lib/. /usr/local/lib/
+          sudo docker cp im7:/usr/local/etc/ImageMagick-7/ /usr/local/etc/ImageMagick-7/
+
+          # Copy system libraries that Ubuntu 24.04 doesn't provide.
+          # NOTE: -L follows symlinks so we get the actual .so file, not a broken link.
+          # libjpeg62-turbo: Ubuntu has libjpeg-turbo8 (different soname)
+          # libomp5: not installed by default on Ubuntu
+          sudo docker cp -L im7:/usr/lib/x86_64-linux-gnu/libjpeg.so.62 /usr/local/lib/
+          sudo docker cp -L im7:/usr/lib/x86_64-linux-gnu/libomp.so.5 /usr/local/lib/
+
+          docker stop im7 && docker rm im7
+
+          # Wrapper script: gm package calls 'convert', IM7 uses 'magick'
+          sudo cp trmnl-ha/ha-trmnl/scripts/imagemagick-wrapper.sh /usr/local/bin/convert
+          sudo chmod +x /usr/local/bin/convert
+          sudo ln -sf /usr/local/bin/magick /usr/local/bin/identify
+          sudo ln -sf /usr/local/bin/magick /usr/local/bin/mogrify
+          sudo ldconfig
+
+          # Verify — must show "ImageMagick 7" and "Q16-HDRI"
+          /usr/local/bin/magick --version
 
       - name: Install dependencies
         working-directory: trmnl-ha/ha-trmnl

--- a/trmnl-ha/ha-trmnl/tests/unit/dithering.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/dithering.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect, beforeAll } from 'bun:test'
+import { execSync } from 'node:child_process'
 import {
   processImage,
   applyDithering,
@@ -16,10 +17,26 @@ import {
   validateDitheringOptions,
 } from '../../lib/dithering.js'
 import type { DitheringMethod } from '../../types/domain.js'
-import gm from 'gm'
+import gmLib from 'gm'
 
-// NOTE: Skipped - ImageMagick image creation times out in CI
-describe.skip('Dithering Module', () => {
+const gm = gmLib.subClass({ imageMagick: true })
+
+// Auto-skip when ImageMagick 7 isn't available (local dev without IM7)
+function hasImageMagick7(): boolean {
+  try {
+    const version = execSync('magick --version 2>/dev/null || convert --version 2>/dev/null', {
+      encoding: 'utf-8',
+      timeout: 5000,
+    })
+    return version.includes('ImageMagick 7')
+  } catch {
+    return false
+  }
+}
+
+const describeDithering = hasImageMagick7() ? describe : describe.skip
+
+describeDithering('Dithering Module', () => {
   let testImageBuffer: Buffer
 
   beforeAll(async () => {
@@ -44,7 +61,7 @@ describe.skip('Dithering Module', () => {
           stdout.on('error', reject)
         })
     })
-  }, 15000)
+  }, 30000)
 
   // ==========================================================================
   // Constants - Test that module exports expected values
@@ -435,7 +452,7 @@ describe.skip('Dithering Module', () => {
             stdout.on('error', reject)
           })
       })
-    }, 15000)
+    }, 30000)
 
     it('produces 1-bit BW images under 50KB for 800x480', async () => {
       const result = await applyDithering(largeTestImage, {


### PR DESCRIPTION
Bun's mock.module() is global and hoisted — it replaces modules for ALL test files in the same process regardless of mock.restore() timing. This caused byos-auth, scheduleStore, and dithering tests to alternate between pass and fail depending on file load order.

Replaced mock.module() with constructor dependency injection on both HttpRouter and Browser classes. Tests now pass mock implementations via constructor parameters, eliminating cross-file contamination entirely.

Also installed ImageMagick 7 Q16-HDRI in CI (docker cp from production image) and replaced describe.skip with runtime IM7 detection so the 33 dithering tests now run in CI instead of being permanently skipped.