### PR TITLE
Added BYOS Hanami URI delivery mode

### DIFF
--- a/trmnl-ha/DOCS.md
+++ b/trmnl-ha/DOCS.md
@@ -360,11 +360,17 @@ The add-on supports multiple webhook payload formats for different e-ink display
 | Format | Use Case |
 |--------|----------|
 | **Raw** (default) | TRMNL devices, custom endpoints |
-| **BYOS Hanami** | Self-hosted [BYOS](https://github.com/usetrmnl/byos) servers |
+| **BYOS Hanami** | Self-hosted [Terminus / BYOS Hanami](https://github.com/usetrmnl/terminus) servers |
+
+For BYOS Hanami, the add-on offers two **delivery modes**:
+
+- **URI mode** (recommended, required for Terminus ≥ 0.52.0): the add-on sends a URL; Terminus fetches the image itself. Set **Add-on URL** to an address **Terminus** can reach — often *not* `localhost`. See the guide for deployment topologies.
+- **Legacy base64 mode**: inlines the image in the JSON body. Only works on Terminus ≤ 0.51.0.
 
 See **[Webhook Formats Guide](docs/webhook-formats.md)** for:
-- Detailed format specifications
+- Detailed format specifications and delivery mode selection
 - JWT authentication setup for BYOS
+- Deployment topology examples for the Add-on URL (Docker, LAN, reverse proxy)
 - How to add custom webhook formats
 
 ---

--- a/trmnl-ha/docs/webhook-formats.md
+++ b/trmnl-ha/docs/webhook-formats.md
@@ -7,7 +7,7 @@ When uploading screenshots via webhooks, the add-on supports multiple payload fo
 | Format | Content-Type | Use Case |
 |--------|--------------|----------|
 | **Raw** (default) | `image/png`, `image/jpeg`, `image/bmp` | Direct binary upload to TRMNL or custom endpoints |
-| **BYOS Hanami** | `application/json` | Self-hosted [BYOS](https://github.com/usetrmnl/byos) servers |
+| **BYOS Hanami** | `application/json` | Self-hosted [Terminus / BYOS Hanami](https://github.com/usetrmnl/terminus) servers |
 
 ---
 
@@ -30,7 +30,85 @@ Authorization: Bearer <optional-token>
 
 ## BYOS Hanami Format
 
-For self-hosted [BYOS (Build Your Own Server)](https://github.com/usetrmnl/byos) installations, this format wraps the image in a JSON payload with metadata.
+For self-hosted [Terminus / BYOS Hanami](https://github.com/usetrmnl/terminus) installations, this format wraps the screen metadata in a JSON payload and delivers the image to `POST /api/screens`.
+
+### Delivery Modes
+
+Terminus supports two incompatible payload shapes depending on its version. The add-on exposes both via a **Delivery Mode** dropdown in the schedule UI.
+
+| Mode | Terminus versions | Image transport |
+|------|-------------------|-----------------|
+| **URI** (recommended) | `≥ 0.11.0`, required from `0.52.0` onward | Terminus fetches the image from the add-on over HTTP |
+| **Legacy base64** | `≤ 0.51.0` only | Add-on inlines the image as base64 in the JSON body |
+
+Base64 support was removed from Terminus in `0.52.0` (released 2026-04-01). New installations should pick **URI** mode; older deployments can stay on **Legacy base64** until they upgrade.
+
+### URI Mode
+
+In URI mode, the add-on sends a small JSON payload referencing a screenshot endpoint on the add-on itself. Terminus then calls back to that URL, downloads the dithered image, and stores it.
+
+**Request:**
+```http
+POST /api/screens
+Content-Type: application/json
+Authorization: <jwt-access-token>
+
+{
+  "screen": {
+    "uri": "http://192.168.1.100:10000/lovelace/0?viewport=800x480&dithering=&dither_method=floyd-steinberg&palette=gray-4",
+    "label": "Home Assistant",
+    "name": "ha-dashboard",
+    "model_id": "1",
+    "preprocessed": true
+  }
+}
+```
+
+**Requirements:**
+
+- `preprocessed: true` tells Terminus to use the image as-is without running its own dithering. The add-on always sends preprocessed images since it dithers locally.
+- The add-on's screenshot endpoint must be reachable without authentication, or the Add-on URL must include any credentials Terminus needs.
+- If URI mode is selected but **Add-on URL** is blank, the add-on throws a clear error at delivery time rather than silently falling back.
+
+#### Setting the Add-on URL
+
+> ⚠️ **This is the URL Terminus will use to reach the add-on — not the URL you use in your browser.**
+>
+> The Add-on URL field must resolve from *Terminus's* network vantage point, not yours. If Terminus runs in Docker on the same host, `http://localhost:10000` will **not** work — inside the Terminus container, `localhost` points at the container itself, and nothing is listening on port `10000` there.
+
+Think of it as two asymmetric network hops:
+
+```
+You (browser) ──────▶ Add-on UI       (your browser resolves "localhost")
+Add-on ──────▶ Terminus               (webhook URL, see "Webhook URL" field)
+Terminus ──────▶ Add-on screenshot    (Add-on URL, see this section)
+```
+
+The second and third hops resolve DNS from different vantage points, so the Webhook URL and the Add-on URL often need to be different strings even when both services are on the same physical machine.
+
+Pick the value that matches your deployment topology:
+
+| Where Terminus runs | Set Add-on URL to | Notes |
+|---|---|---|
+| Docker on the same host as the add-on (Docker Desktop on Mac/Windows) | `http://host.docker.internal:10000` | Docker Desktop's built-in DNS name for the host machine |
+| Docker on the same Linux host | `http://172.17.0.1:10000` or your LAN IP | `172.17.0.1` is the default docker bridge gateway; LAN IP also works |
+| A different machine on the same LAN | `http://<add-on-lan-ip>:10000` | Use the add-on host's routable IP, never `localhost` |
+| Behind a reverse proxy / public URL | `https://trmnl.example.com` | Whatever public hostname forwards to the add-on's port 10000 |
+| As a Home Assistant add-on, accessed via ingress | The add-on's ingress URL | See your HA installation's external ingress configuration |
+
+**Verification shortcut.** Before retrying a failed schedule, shell into the Terminus container and confirm it can reach the add-on:
+
+```sh
+docker compose -p terminus-development exec web \
+  curl -sI http://host.docker.internal:10000/health
+# Expected: HTTP/1.1 200 OK
+```
+
+If that curl fails, fix the URL before touching anything else — every downstream error (`ECONNREFUSED`, `improper image header` from MiniMagick, 500 from Terminus) traces back to this one setting.
+
+### Legacy Base64 Mode
+
+Legacy mode embeds the image directly in the JSON body. Keep it selected only if your Terminus is `≤ 0.51.0`.
 
 **Request:**
 ```http
@@ -43,10 +121,21 @@ Authorization: <jwt-access-token>
     "data": "<base64-encoded-image>",
     "label": "Home Assistant",
     "name": "ha-dashboard",
-    "model_id": "1"
+    "model_id": "1",
+    "file_name": "ha-dashboard.png",
+    "preprocessed": true
   }
 }
 ```
+
+### Backward Compatibility
+
+Schedules created before this feature shipped have no `delivery_mode` field in their stored config. The add-on treats them as follows:
+
+- No `delivery_mode` + no Add-on URL → **Legacy base64** (preserves pre-existing behavior)
+- No `delivery_mode` + Add-on URL configured → **URI**
+- Explicit `delivery_mode: 'data'` → **Legacy base64** (user choice wins even if Add-on URL is set)
+- Explicit `delivery_mode: 'uri'` → **URI** (throws if Add-on URL is missing)
 
 ### Configuration Fields
 
@@ -55,7 +144,9 @@ Authorization: <jwt-access-token>
 | `label` | Display name shown in BYOS UI |
 | `name` | Unique screen identifier (slug format) |
 | `model_id` | BYOS device model ID (from your BYOS setup) |
-| `preprocessed` | Whether the image is already optimized for e-ink |
+| `preprocessed` | Whether the image is already optimized for e-ink (always `true` from the add-on) |
+| `delivery_mode` | `'uri'` or `'data'`. Omitted on legacy schedules. |
+| `addon_base_url` | URL of this add-on as reachable **from Terminus**, required for URI mode. See [Setting the Add-on URL](#setting-the-add-on-url). |
 
 ### JWT Authentication
 
@@ -107,8 +198,11 @@ export class YourFormatTransformer implements FormatTransformer {
     imageBuffer: Buffer,
     format: ImageFormat,
     config?: YourFormatConfig,
+    screenshotUrl?: string,
   ): WebhookPayload {
-    // Transform the image buffer into your payload format
+    // Transform the image buffer into your payload format.
+    // `screenshotUrl` is only set for URI-mode formats (see BYOS Hanami).
+    // Formats that inline the image can ignore it.
     return {
       body: JSON.stringify({
         image: imageBuffer.toString('base64'),
@@ -182,14 +276,18 @@ Schedule Execution
        ↓
 ScheduleExecutor.call()
        ↓
+#buildScreenshotUrl(schedule)   ← URI mode only; undefined otherwise
+       ↓
 uploadToWebhook(options)
        ↓
-getTransformer(webhookFormat)  ← Strategy selection
+getTransformer(webhookFormat)   ← Strategy selection
        ↓
-transformer.transform(buffer, format, config)
-       ↓
+transformer.transform(buffer, format, config, screenshotUrl)
+       ↓                         ← BYOS transformer branches on delivery_mode
 fetch(webhookUrl, { body, headers })
 ```
+
+For BYOS in URI mode, Terminus then performs a second round-trip back to the add-on's screenshot endpoint to download the actual image.
 
 The transformer is responsible for:
 - Converting the image buffer to the target payload format

--- a/trmnl-ha/ha-trmnl/html/js/app.ts
+++ b/trmnl-ha/ha-trmnl/html/js/app.ts
@@ -33,7 +33,9 @@ import type {
   WebhookFormat,
   WebhookFormatConfig,
   ByosAuthConfig,
+  ByosDeliveryMode,
 } from '../../types/domain.js'
+import { BYOS_DEFAULT_DELIVERY_MODE } from '../../types/domain.js'
 
 // =============================================================================
 // FORM PARSING HELPERS
@@ -531,6 +533,9 @@ class App {
     if (format === 'byos-hanami') {
       const name = input('s_byos_name') || 'ha-dashboard'
       const authEnabled = checkbox('s_byos_auth_enabled')
+      const rawDeliveryMode = select('s_byos_delivery_mode')
+      const deliveryMode: ByosDeliveryMode =
+        rawDeliveryMode === 'uri' ? 'uri' : BYOS_DEFAULT_DELIVERY_MODE
 
       // Preserve existing auth tokens (managed by byosLogin/byosLogout, not form)
       // If auth is enabled but no tokens yet, create empty auth object with enabled: true
@@ -544,6 +549,8 @@ class App {
           name,
           model_id: input('s_byos_model_id') || '1',
           preprocessed: true,
+          delivery_mode: deliveryMode,
+          addon_base_url: input('s_byos_addon_url') || undefined,
           auth: authEnabled ? (existingAuth ?? { enabled: true }) : undefined,
         },
       }
@@ -906,6 +913,19 @@ class App {
     }
 
     // Save the schedule with new auth state
+    await this.updateScheduleFromForm()
+  }
+
+  /**
+   * Toggles BYOS delivery mode (URI vs legacy base64) and shows/hides the
+   * Add-on URL field which is only meaningful for URI mode.
+   */
+  async toggleByosDeliveryMode(mode: string): Promise<void> {
+    const urlField = document.getElementById('s_byos_addon_url_field')
+    if (urlField) {
+      urlField.classList.toggle('hidden', mode !== 'uri')
+    }
+
     await this.updateScheduleFromForm()
   }
 

--- a/trmnl-ha/ha-trmnl/html/js/device-presets.ts
+++ b/trmnl-ha/ha-trmnl/html/js/device-presets.ts
@@ -140,6 +140,16 @@ export class DevicePresetsManager {
       heightInput.dispatchEvent(new Event('change'))
     }
 
+    // Update crop dimensions to match device viewport
+    const cropWidth = document.getElementById('s_crop_width') as HTMLInputElement | null
+    const cropHeight = document.getElementById('s_crop_height') as HTMLInputElement | null
+    if (cropWidth && device.viewport?.width) {
+      cropWidth.value = device.viewport.width
+    }
+    if (cropHeight && device.viewport?.height) {
+      cropHeight.value = device.viewport.height
+    }
+
     if (device.rotate) {
       const rotateSelect = document.getElementById(
         's_rotate',

--- a/trmnl-ha/ha-trmnl/html/js/ui-renderer.ts
+++ b/trmnl-ha/ha-trmnl/html/js/ui-renderer.ts
@@ -16,6 +16,7 @@
  */
 
 import type { Schedule } from '../../types/domain.js'
+import { BYOS_DEFAULT_DELIVERY_MODE } from '../../types/domain.js'
 import type { PaletteOption } from './palette-options.js'
 import { buildScreenshotParams } from '../shared/build-screenshot-params.js'
 import { resolveScreenshotTarget } from '../shared/screenshot-target.js'
@@ -305,6 +306,26 @@ export class RenderScheduleContent {
                 onchange="window.app.updateScheduleFromForm()"
                 placeholder="1"
                 title="BYOS model ID for your device" />
+            </div>
+            <div>
+              <label class="block text-xs text-gray-600 mb-1">Delivery Mode</label>
+              <select id="s_byos_delivery_mode"
+                class="w-full px-2 py-1 text-sm border rounded-md" style="border-color: var(--primary-light)"
+                onchange="window.app.toggleByosDeliveryMode(this.value)"
+                title="How Terminus receives the screenshot">
+                <option value="data" ${(byosConfig?.delivery_mode ?? BYOS_DEFAULT_DELIVERY_MODE) === 'data' ? 'selected' : ''}>Legacy base64 (Terminus ≤ 0.51.0)</option>
+                <option value="uri" ${byosConfig?.delivery_mode === 'uri' ? 'selected' : ''}>URI (Terminus ≥ 0.52.0, recommended)</option>
+              </select>
+              <p class="text-xs text-gray-500 mt-1">Base64 was removed in Terminus 0.52.0. Pick URI if you're on 0.52.0 or newer.</p>
+            </div>
+            <div id="s_byos_addon_url_field" class="${(byosConfig?.delivery_mode ?? BYOS_DEFAULT_DELIVERY_MODE) === 'uri' ? '' : 'hidden'}">
+              <label class="block text-xs text-gray-600 mb-1">Add-on URL</label>
+              <input type="text" id="s_byos_addon_url" value="${byosConfig?.addon_base_url || ''}"
+                class="w-full px-2 py-1 text-sm border rounded-md" style="border-color: var(--primary-light)"
+                onchange="window.app.updateScheduleFromForm()"
+                placeholder="http://192.168.1.100:10000"
+                title="External URL of this add-on (required for Terminus to fetch screenshots)" />
+              <p class="text-xs text-gray-500 mt-1">Terminus fetches screenshots from this URL</p>
             </div>
           </div>
 

--- a/trmnl-ha/ha-trmnl/lib/scheduler/schedule-executor.ts
+++ b/trmnl-ha/ha-trmnl/lib/scheduler/schedule-executor.ts
@@ -12,6 +12,8 @@ import {
   uploadToWebhook,
   buildParams,
 } from './services.js'
+import { resolveScreenshotTarget } from '../../html/shared/screenshot-target.js'
+import { buildScreenshotParams } from '../../html/shared/build-screenshot-params.js'
 import {
   SCHEDULER_MAX_RETRIES,
   SCHEDULER_RETRY_DELAY_MS,
@@ -134,6 +136,27 @@ export class ScheduleExecutor {
     return outputPath
   }
 
+  /** Builds the screenshot endpoint URL for BYOS URI mode. Returns undefined when URI mode is not applicable. */
+  #buildScreenshotUrl(schedule: Schedule): string | undefined {
+    const byos = schedule.webhook_format?.byosConfig
+    if (!byos?.addon_base_url) return undefined
+    if (byos.delivery_mode === 'data') return undefined
+
+    const target = resolveScreenshotTarget(schedule)
+    const params = buildScreenshotParams(schedule)
+
+    // NOTE: In generic mode the router serves the UI at `/` unless `url` is
+    // present in the query. Thread target_url through so Terminus's fetch
+    // hits the screenshot handler instead of the UI HTML.
+    if (!target.isHAMode && target.fullUrl) {
+      params.append('url', target.fullUrl)
+    }
+
+    const path = target.path.replace(/^\//, '')
+
+    return `${byos.addon_base_url.replace(/\/+$/, '')}/${path}?${params.toString()}`
+  }
+
   /** Uploads to webhook if configured, returns result for UI feedback */
   async #uploadIfConfigured(
     schedule: Schedule,
@@ -143,6 +166,7 @@ export class ScheduleExecutor {
     if (!schedule.webhook_url) return undefined
 
     const webhookUrl = schedule.webhook_url
+    const screenshotUrl = this.#buildScreenshotUrl(schedule)
 
     try {
       const result = await uploadToWebhook({
@@ -151,6 +175,7 @@ export class ScheduleExecutor {
         imageBuffer,
         format: format as 'png' | 'jpeg' | 'bmp',
         webhookFormat: schedule.webhook_format,
+        screenshotUrl,
         onTokenRefresh: (newTokens) => {
           const byosConfig = schedule.webhook_format?.byosConfig
           if (!byosConfig?.auth) return

--- a/trmnl-ha/ha-trmnl/lib/scheduler/webhook-delivery.ts
+++ b/trmnl-ha/ha-trmnl/lib/scheduler/webhook-delivery.ts
@@ -120,6 +120,8 @@ export interface WebhookDeliveryOptions {
   format: ImageFormat
   /** Webhook payload format (null/undefined = 'raw' for backward compat) */
   webhookFormat?: WebhookFormatConfig | null
+  /** Screenshot URL for BYOS URI mode (Terminus fetches from this URL) */
+  screenshotUrl?: string
   /** Callback to persist refreshed BYOS JWT tokens */
   onTokenRefresh?: (newTokens: TokenResponse) => void
 }
@@ -147,6 +149,7 @@ export async function uploadToWebhook(
     imageBuffer,
     format,
     webhookFormat,
+    screenshotUrl,
     onTokenRefresh,
   } = options
 
@@ -160,6 +163,7 @@ export async function uploadToWebhook(
     imageBuffer,
     format,
     byosConfig,
+    screenshotUrl,
   )
 
   log.info`Sending webhook: ${webhookUrl} (${contentType}, ${imageBuffer.length} bytes, format: ${webhookFormat?.format ?? 'raw'})`

--- a/trmnl-ha/ha-trmnl/lib/scheduler/webhook-formats.ts
+++ b/trmnl-ha/ha-trmnl/lib/scheduler/webhook-formats.ts
@@ -12,6 +12,7 @@ import type {
   ImageFormat,
   WebhookFormatConfig,
   ByosHanamiConfig,
+  ByosDeliveryMode,
 } from '../../types/domain.js'
 
 /** MIME type mapping for image formats */
@@ -37,12 +38,14 @@ export interface FormatTransformer {
    * @param imageBuffer - Raw image data
    * @param format - Image format (png, jpeg, bmp)
    * @param config - Optional format-specific configuration
+   * @param screenshotUrl - Optional screenshot URL for URI mode
    * @returns Payload with body and content type
    */
   transform(
     imageBuffer: Buffer,
     format: ImageFormat,
     config?: unknown,
+    screenshotUrl?: string,
   ): WebhookPayload
 }
 
@@ -61,28 +64,20 @@ export class RawFormatTransformer implements FormatTransformer {
 
 /**
  * BYOS Hanami API format transformer.
- * Wraps image in JSON with base64 encoding and metadata.
  *
- * BYOS API expects:
- * ```
- * POST /api/screens
- * Content-Type: application/json
- * {
- *   "screen": {
- *     "data": "<base64-encoded-image>",
- *     "label": "Home Assistant",
- *     "name": "ha-dashboard",
- *     "model_id": "1",
- *     "file_name": "ha-dashboard.png"
- *   }
- * }
- * ```
+ * Two delivery modes, user-selectable via `config.delivery_mode`:
+ * - `uri`: sends screenshot endpoint URL; Terminus fetches it.
+ *   Required for Terminus >= 0.52.0 (base64 support was removed).
+ * - `data`: sends base64-encoded image; only works on Terminus <= 0.51.0.
+ *
+ * Mode selection (including backward-compat defaults) lives in #selectMode.
  */
 export class ByosHanamiFormatTransformer implements FormatTransformer {
   transform(
     imageBuffer: Buffer,
     format: ImageFormat,
     config?: ByosHanamiConfig,
+    screenshotUrl?: string,
   ): WebhookPayload {
     if (!config) {
       throw new Error(
@@ -90,6 +85,70 @@ export class ByosHanamiFormatTransformer implements FormatTransformer {
       )
     }
 
+    const mode = this.#selectMode(config, screenshotUrl)
+
+    if (mode === 'uri') {
+      // NOTE: #selectMode guarantees screenshotUrl is defined when mode is 'uri'
+      return this.#buildUriPayload(config, screenshotUrl!)
+    }
+
+    return this.#buildDataPayload(imageBuffer, format, config)
+  }
+
+  /**
+   * Decides which delivery mode to use for this request.
+   *
+   * Policy: if the schedule was already set up for data mode, keep data;
+   * otherwise URI mode is the default.
+   *
+   * - Explicit `data` wins even when a screenshot URL is available.
+   * - Legacy schedules (no `delivery_mode`, no `addon_base_url`) are treated
+   *   as data-mode setups and preserved as-is.
+   * - Explicit `uri` without a screenshot URL is a misconfiguration — fail
+   *   loud rather than silently falling back.
+   */
+  #selectMode(
+    config: ByosHanamiConfig,
+    screenshotUrl?: string,
+  ): ByosDeliveryMode {
+    if (config.delivery_mode === 'data') return 'data'
+    if (config.delivery_mode === undefined && !screenshotUrl) return 'data'
+
+    if (!screenshotUrl) {
+      throw new Error(
+        'BYOS Hanami URI mode requires "Add-on URL" to be set in the schedule config.',
+      )
+    }
+    return 'uri'
+  }
+
+  /** URI mode: Terminus fetches the image from the add-on's screenshot endpoint */
+  #buildUriPayload(
+    config: ByosHanamiConfig,
+    screenshotUrl: string,
+  ): WebhookPayload {
+    const payload = {
+      screen: {
+        uri: screenshotUrl,
+        label: config.label,
+        name: config.name,
+        model_id: config.model_id,
+        preprocessed: config.preprocessed,
+      },
+    }
+
+    return {
+      body: JSON.stringify(payload),
+      contentType: 'application/json',
+    }
+  }
+
+  /** Data mode (legacy): base64-encoded image sent directly */
+  #buildDataPayload(
+    imageBuffer: Buffer,
+    format: ImageFormat,
+    config: ByosHanamiConfig,
+  ): WebhookPayload {
     const base64Data = imageBuffer.toString('base64')
     const fileName = `${config.name}.${format}`
 
@@ -100,6 +159,7 @@ export class ByosHanamiFormatTransformer implements FormatTransformer {
         name: config.name,
         model_id: config.model_id,
         file_name: fileName,
+        preprocessed: config.preprocessed,
       },
     }
 

--- a/trmnl-ha/ha-trmnl/tests/unit/webhook-formats.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/webhook-formats.test.ts
@@ -56,64 +56,138 @@ describe('ByosHanamiFormatTransformer', () => {
     preprocessed: true,
   }
 
-  it('returns JSON string body', () => {
-    const imageBuffer = Buffer.from('test image data')
-    const result = transformer.transform(imageBuffer, 'png', validConfig)
+  const imageBuffer = Buffer.from('test')
 
-    expect(typeof result.body).toBe('string')
-    // Should be valid JSON
-    expect(() => JSON.parse(result.body as string)).not.toThrow()
+  describe('URI mode (with screenshotUrl)', () => {
+    const screenshotUrl =
+      'http://192.168.1.100:10000/lovelace/default?viewport=800x480&dithering=&dither_method=floyd-steinberg&palette=gray-4'
+
+    it('sends uri instead of data', () => {
+      const result = transformer.transform(imageBuffer, 'png', validConfig, screenshotUrl)
+      const payload = JSON.parse(result.body as string)
+
+      expect(payload.screen.uri).toBe(screenshotUrl)
+      expect(payload.screen.data).toBeUndefined()
+      expect(payload.screen.file_name).toBeUndefined()
+    })
+
+    it('includes label, name, model_id, and preprocessed', () => {
+      const result = transformer.transform(imageBuffer, 'png', validConfig, screenshotUrl)
+      const payload = JSON.parse(result.body as string)
+
+      expect(payload.screen.label).toBe('Home Assistant')
+      expect(payload.screen.name).toBe('ha-dashboard')
+      expect(payload.screen.model_id).toBe('1')
+      expect(payload.screen.preprocessed).toBe(true)
+    })
+
+    it('sets Content-Type to application/json', () => {
+      const result = transformer.transform(imageBuffer, 'png', validConfig, screenshotUrl)
+
+      expect(result.contentType).toBe('application/json')
+    })
   })
 
-  it('sets Content-Type to application/json', () => {
-    const imageBuffer = Buffer.from('test')
-    const result = transformer.transform(imageBuffer, 'png', validConfig)
+  describe('data mode (legacy fallback, no screenshotUrl)', () => {
+    it('returns JSON string body', () => {
+      const result = transformer.transform(imageBuffer, 'png', validConfig)
 
-    expect(result.contentType).toBe('application/json')
+      expect(typeof result.body).toBe('string')
+      expect(() => JSON.parse(result.body as string)).not.toThrow()
+    })
+
+    it('sets Content-Type to application/json', () => {
+      const result = transformer.transform(imageBuffer, 'png', validConfig)
+
+      expect(result.contentType).toBe('application/json')
+    })
+
+    it('base64 encodes image data correctly', () => {
+      // NOTE: Uses a distinctive payload so the round-trip decode is meaningful
+      const distinctiveBuffer = Buffer.from('test image data')
+      const result = transformer.transform(distinctiveBuffer, 'png', validConfig)
+      const payload = JSON.parse(result.body as string)
+
+      const decoded = Buffer.from(payload.screen.data, 'base64').toString()
+      expect(decoded).toBe('test image data')
+    })
+
+    it('includes all required BYOS fields', () => {
+      const result = transformer.transform(imageBuffer, 'png', validConfig)
+      const payload = JSON.parse(result.body as string)
+
+      expect(payload.screen).toBeDefined()
+      expect(payload.screen.data).toBeDefined()
+      expect(payload.screen.label).toBe('Home Assistant')
+      expect(payload.screen.name).toBe('ha-dashboard')
+      expect(payload.screen.model_id).toBe('1')
+      expect(payload.screen.file_name).toBe('ha-dashboard.png')
+      expect(payload.screen.preprocessed).toBe(true)
+    })
+
+    it('sets correct file_name extension for JPEG', () => {
+      const result = transformer.transform(imageBuffer, 'jpeg', validConfig)
+      const payload = JSON.parse(result.body as string)
+
+      expect(payload.screen.file_name).toBe('ha-dashboard.jpeg')
+    })
+
+    it('sets correct file_name extension for BMP', () => {
+      const result = transformer.transform(imageBuffer, 'bmp', validConfig)
+      const payload = JSON.parse(result.body as string)
+
+      expect(payload.screen.file_name).toBe('ha-dashboard.bmp')
+    })
   })
 
-  it('base64 encodes image data correctly', () => {
-    const imageBuffer = Buffer.from('test image data')
-    const result = transformer.transform(imageBuffer, 'png', validConfig)
-    const payload = JSON.parse(result.body as string)
+  describe('explicit delivery_mode selection', () => {
+    const screenshotUrl = 'http://192.168.1.100:10000/lovelace/default?viewport=800x480'
 
-    // Decode base64 and verify
-    const decoded = Buffer.from(payload.screen.data, 'base64').toString()
-    expect(decoded).toBe('test image data')
-  })
+    it('respects explicit data mode even when screenshotUrl is present', () => {
+      const config = { ...validConfig, delivery_mode: 'data' as const }
+      const result = transformer.transform(imageBuffer, 'png', config, screenshotUrl)
+      const payload = JSON.parse(result.body as string)
 
-  it('includes all required BYOS fields', () => {
-    const imageBuffer = Buffer.from('test')
-    const result = transformer.transform(imageBuffer, 'png', validConfig)
-    const payload = JSON.parse(result.body as string)
+      expect(payload.screen.data).toBeDefined()
+      expect(payload.screen.file_name).toBe('ha-dashboard.png')
+      expect(payload.screen.uri).toBeUndefined()
+    })
 
-    expect(payload.screen).toBeDefined()
-    expect(payload.screen.data).toBeDefined()
-    expect(payload.screen.label).toBe('Home Assistant')
-    expect(payload.screen.name).toBe('ha-dashboard')
-    expect(payload.screen.model_id).toBe('1')
-    expect(payload.screen.file_name).toBe('ha-dashboard.png')
-  })
+    it('uses uri mode when explicitly selected and screenshotUrl is present', () => {
+      const config = { ...validConfig, delivery_mode: 'uri' as const }
+      const result = transformer.transform(imageBuffer, 'png', config, screenshotUrl)
+      const payload = JSON.parse(result.body as string)
 
-  it('sets correct file_name extension for JPEG', () => {
-    const imageBuffer = Buffer.from('test')
-    const result = transformer.transform(imageBuffer, 'jpeg', validConfig)
-    const payload = JSON.parse(result.body as string)
+      expect(payload.screen.uri).toBe(screenshotUrl)
+      expect(payload.screen.data).toBeUndefined()
+    })
 
-    expect(payload.screen.file_name).toBe('ha-dashboard.jpeg')
-  })
+    it('throws when uri mode is explicitly selected but screenshotUrl is missing', () => {
+      const config = { ...validConfig, delivery_mode: 'uri' as const }
 
-  it('sets correct file_name extension for BMP', () => {
-    const imageBuffer = Buffer.from('test')
-    const result = transformer.transform(imageBuffer, 'bmp', validConfig)
-    const payload = JSON.parse(result.body as string)
+      expect(() => transformer.transform(imageBuffer, 'png', config)).toThrow(
+        /URI mode requires "Add-on URL"/,
+      )
+    })
 
-    expect(payload.screen.file_name).toBe('ha-dashboard.bmp')
+    it('treats legacy config (no delivery_mode, no url) as data mode', () => {
+      const result = transformer.transform(imageBuffer, 'png', validConfig)
+      const payload = JSON.parse(result.body as string)
+
+      expect(payload.screen.data).toBeDefined()
+      expect(payload.screen.uri).toBeUndefined()
+    })
+
+    it('defaults to uri when delivery_mode is unset but screenshotUrl is present', () => {
+      const result = transformer.transform(imageBuffer, 'png', validConfig, screenshotUrl)
+      const payload = JSON.parse(result.body as string)
+
+      expect(payload.screen.uri).toBe(screenshotUrl)
+      expect(payload.screen.data).toBeUndefined()
+    })
   })
 
   it('throws error when config is missing', () => {
-    const imageBuffer = Buffer.from('test')
-
     expect(() => transformer.transform(imageBuffer, 'png')).toThrow(
       'BYOS Hanami format requires config with label, name, and model_id',
     )
@@ -150,7 +224,6 @@ describe('getTransformer factory', () => {
   })
 
   it('returns RawFormatTransformer for unknown format (defensive fallback)', () => {
-    // Force unknown format via type assertion (simulates future format or data corruption)
     const config = {
       format: 'unknown-format',
     } as unknown as WebhookFormatConfig

--- a/trmnl-ha/ha-trmnl/types/domain.ts
+++ b/trmnl-ha/ha-trmnl/types/domain.ts
@@ -135,6 +135,23 @@ export interface ScreenshotParams {
 /** Supported webhook payload formats */
 export type WebhookFormat = 'raw' | 'byos-hanami'
 
+/**
+ * BYOS Hanami payload delivery mode.
+ *
+ * - `uri`: Sends `{ screen: { uri } }`. Terminus fetches the image from the
+ *   add-on. Supported by Terminus >= 0.11.0, required from 0.52.0 onwards.
+ * - `data`: Sends `{ screen: { data, file_name } }` with base64 payload.
+ *   Legacy mode, only accepted by Terminus <= 0.51.0.
+ */
+export type ByosDeliveryMode = 'uri' | 'data'
+
+/**
+ * Default delivery mode shown in the UI when a schedule has no explicit choice.
+ * Keep in sync with the backward-compat branch in
+ * `ByosHanamiFormatTransformer#selectMode`.
+ */
+export const BYOS_DEFAULT_DELIVERY_MODE: ByosDeliveryMode = 'data'
+
 /** BYOS Hanami API configuration */
 export interface ByosHanamiConfig {
   /** Display label shown in BYOS UI */
@@ -145,6 +162,10 @@ export interface ByosHanamiConfig {
   model_id: string
   /** Whether the screen has been preprocessed */
   preprocessed: boolean
+  /** External URL of this add-on (e.g., http://192.168.1.100:10000) for Terminus URI mode */
+  addon_base_url?: string
+  /** Payload delivery mode. Omitted on legacy schedules; treat as 'data' for backward compat. */
+  delivery_mode?: ByosDeliveryMode
   /** JWT authentication settings */
   auth?: ByosAuthConfig
 }


### PR DESCRIPTION
Terminus 0.52.0 removed base64 payload support, so the add-on needs a way to hand Terminus a URL it can fetch. URI mode sends the add-on's screenshot endpoint URL and lets Terminus pull the image itself.

Legacy base64 mode is preserved as an opt-in for Terminus ≤ 0.51.0 users. A delivery-mode selector in the BYOS schedule config defaults to `data` so existing schedules keep working unchanged until users opt in to URI mode.

Includes supporting pieces for the feature:
- `addon_base_url` + `ByosDeliveryMode` added to the BYOS config
- `BYOS_DEFAULT_DELIVERY_MODE` constant shared by UI and extractor
- Screenshot URL builder threads `url` query param in generic mode so Terminus fetches hit the screenshot handler, not the UI HTML
- Device preset selection auto-fills crop dimensions from viewport
- Webhook format tests restructured by mode (URI / data / explicit)


<img width="353" height="626" alt="Screenshot 2026-04-14 at 17 37 37" src="https://github.com/user-attachments/assets/7931306d-5617-43f4-b9af-74e6d49e69a8" />
