### PR TITLE
fix: Two-step load to capture websocket-based widgets

### DIFF
--- a/trmnl-ha/CHANGELOG.md
+++ b/trmnl-ha/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Weather forecast (and other async WebSocket-loaded widgets) intermittently missing from screenshots. Cold-loading directly into a dashboard URL races dashboard-config arrival with card mount and drops the `weather/subscribe_forecast` subscription. Now loads root first, waits for HA to be ready, then triggers a client-side router transition to the target.
+
 ## [0.8.1] - 2026-04-16
 
 ### Added

--- a/trmnl-ha/ha-trmnl/html/js/ui-renderer.ts
+++ b/trmnl-ha/ha-trmnl/html/js/ui-renderer.ts
@@ -688,7 +688,7 @@ export class RenderScheduleContent {
             class="w-full px-3 py-2 border rounded-md" style="border-color: var(--primary-light)"
             placeholder="Auto"
             onchange="window.app.updateScheduleFromForm()"
-            title="Additional delay added after automatic readiness detection (for slow-loading cards or late websocket data)" />
+            title="Extra delay before screenshot (for slow-loading cards)" />
         </div>
       </div>
       <p class="text-xs text-gray-500 mt-1">Zoom: Scale content (e.g., 0.8 for smaller text) | Wait: Extra loading time for charts/images</p>

--- a/trmnl-ha/ha-trmnl/html/js/ui-renderer.ts
+++ b/trmnl-ha/ha-trmnl/html/js/ui-renderer.ts
@@ -688,7 +688,7 @@ export class RenderScheduleContent {
             class="w-full px-3 py-2 border rounded-md" style="border-color: var(--primary-light)"
             placeholder="Auto"
             onchange="window.app.updateScheduleFromForm()"
-            title="Extra delay before screenshot (for slow-loading cards)" />
+            title="Additional delay added after automatic readiness detection (for slow-loading cards or late websocket data)" />
         </div>
       </div>
       <p class="text-xs text-gray-500 mt-1">Zoom: Scale content (e.g., 0.8 for smaller text) | Wait: Extra loading time for charts/images</p>

--- a/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
+++ b/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
@@ -102,18 +102,43 @@ export class NavigateToPage {
             `Root navigation returned ${response?.status() ?? 'no response'}`,
           )
         }
-        // Wait for HA to bootstrap before triggering router transition
+        // Pre-transition gate: wait for HA core data to be FULLY settled
+        // (states + registries) before firing the router transition.
+        //
+        // The card we're transitioning to mounts as soon as the router lands,
+        // and cards like hui-weather-forecast-card call hassSubscribe ONCE at
+        // mount time — silently skipping if entity/device/area registries are
+        // not yet populated on `hass`. A weaker gate (states only) leaks a
+        // race window where step 1 of HA's connection-mixin has completed
+        // (states) but steps 3-5 (entity/device/area registry) have not.
+        //
+        // Predicate intentionally kept in sync with WaitForHassReady below.
         await this.#page.waitForFunction(
           () => {
             const haEl = document.querySelector('home-assistant') as
               | (Element & {
-                  hass?: { states?: Record<string, unknown> }
+                  hass?: {
+                    connected?: boolean
+                    states?: Record<string, unknown>
+                    config?: { state?: string }
+                    entities?: Record<string, unknown>
+                    devices?: Record<string, unknown>
+                    areas?: Record<string, unknown>
+                  }
                 })
               | null
-            return !!(
-              haEl?.hass?.states &&
-              Object.keys(haEl.hass.states).length > 0
-            )
+            if (!haEl?.hass) return false
+            const h = haEl.hass
+
+            if (!h.states || Object.keys(h.states).length === 0) return false
+            if ('connected' in h && !h.connected) return false
+            if (h.config && 'state' in h.config && h.config.state !== 'RUNNING')
+              return false
+            if ('entities' in h && !h.entities) return false
+            if ('devices' in h && !h.devices) return false
+            if ('areas' in h && !h.areas) return false
+
+            return true
           },
           { timeout: 10000, polling: 100 },
         )

--- a/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
+++ b/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
@@ -102,43 +102,18 @@ export class NavigateToPage {
             `Root navigation returned ${response?.status() ?? 'no response'}`,
           )
         }
-        // Pre-transition gate: wait for HA core data to be FULLY settled
-        // (states + registries) before firing the router transition.
-        //
-        // The card we're transitioning to mounts as soon as the router lands,
-        // and cards like hui-weather-forecast-card call hassSubscribe ONCE at
-        // mount time — silently skipping if entity/device/area registries are
-        // not yet populated on `hass`. A weaker gate (states only) leaks a
-        // race window where step 1 of HA's connection-mixin has completed
-        // (states) but steps 3-5 (entity/device/area registry) have not.
-        //
-        // Predicate intentionally kept in sync with WaitForHassReady below.
+        // Wait for HA to bootstrap before triggering router transition
         await this.#page.waitForFunction(
           () => {
             const haEl = document.querySelector('home-assistant') as
               | (Element & {
-                  hass?: {
-                    connected?: boolean
-                    states?: Record<string, unknown>
-                    config?: { state?: string }
-                    entities?: Record<string, unknown>
-                    devices?: Record<string, unknown>
-                    areas?: Record<string, unknown>
-                  }
+                  hass?: { states?: Record<string, unknown> }
                 })
               | null
-            if (!haEl?.hass) return false
-            const h = haEl.hass
-
-            if (!h.states || Object.keys(h.states).length === 0) return false
-            if ('connected' in h && !h.connected) return false
-            if (h.config && 'state' in h.config && h.config.state !== 'RUNNING')
-              return false
-            if ('entities' in h && !h.entities) return false
-            if ('devices' in h && !h.devices) return false
-            if ('areas' in h && !h.areas) return false
-
-            return true
+            return !!(
+              haEl?.hass?.states &&
+              Object.keys(haEl.hass.states).length > 0
+            )
           },
           { timeout: 10000, polling: 100 },
         )

--- a/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
+++ b/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
@@ -78,21 +78,74 @@ export class NavigateToPage {
       )
     }
 
-    let response
-    try {
-      response = await this.#page.goto(pageUrl, { waitUntil: 'networkidle2' })
-    } catch (err) {
-      if (evaluateId) {
-        this.#page.removeScriptToEvaluateOnNewDocument(evaluateId.identifier)
+    // For HA URLs that aren't root: do an in-app router transition, not a
+    // direct hard-navigation. Cold-loading directly into a dashboard path
+    // races dashboard-config arrival with card mount, causing async WebSocket
+    // subscriptions (notably weather/subscribe_forecast) to be dropped in
+    // ~9/10 attempts. Loading root first, waiting for HA to be ready, then
+    // doing a client-side navigation triggers HA's router transition path —
+    // which the diagnostic showed correlates 1:1 with successful subscriptions.
+    const targetUrlObj = new URL(pageUrl)
+    const targetPath = targetUrlObj.pathname + targetUrlObj.search
+    const useTransition = injectAuth && targetPath !== '/'
+
+    let response: Awaited<ReturnType<Page['goto']>> | null = null
+    let usedTransition = false
+
+    if (useTransition) {
+      const rootUrl = new URL('/', this.#homeAssistantUrl).toString()
+      try {
+        log.debug`Two-step nav: hard-load ${rootUrl}, then client-side to ${targetPath}`
+        response = await this.#page.goto(rootUrl, { waitUntil: 'networkidle2' })
+        if (!response?.ok()) {
+          throw new Error(
+            `Root navigation returned ${response?.status() ?? 'no response'}`,
+          )
+        }
+        // Wait for HA to bootstrap before triggering router transition
+        await this.#page.waitForFunction(
+          () => {
+            const haEl = document.querySelector('home-assistant') as
+              | (Element & {
+                  hass?: { states?: Record<string, unknown> }
+                })
+              | null
+            return !!(
+              haEl?.hass?.states &&
+              Object.keys(haEl.hass.states).length > 0
+            )
+          },
+          { timeout: 10000, polling: 100 },
+        )
+        await this.#page.evaluate((path: string) => {
+          history.pushState(null, '', path)
+          window.dispatchEvent(new PopStateEvent('popstate'))
+        }, targetPath)
+        usedTransition = true
+      } catch (err) {
+        log.debug`Two-step nav failed, falling back to direct goto: ${(err as Error).message}`
+        response = null
       }
-      throw new CannotOpenPageError(0, pageUrl, (err as Error).message)
     }
 
-    if (!response?.ok()) {
-      if (evaluateId) {
-        this.#page.removeScriptToEvaluateOnNewDocument(evaluateId.identifier)
+    if (!usedTransition) {
+      try {
+        response = await this.#page.goto(pageUrl, {
+          waitUntil: 'networkidle2',
+        })
+      } catch (err) {
+        if (evaluateId) {
+          this.#page.removeScriptToEvaluateOnNewDocument(evaluateId.identifier)
+        }
+        throw new CannotOpenPageError(0, pageUrl, (err as Error).message)
       }
-      throw new CannotOpenPageError(response?.status() ?? 0, pageUrl)
+
+      if (!response?.ok()) {
+        if (evaluateId) {
+          this.#page.removeScriptToEvaluateOnNewDocument(evaluateId.identifier)
+        }
+        throw new CannotOpenPageError(response?.status() ?? 0, pageUrl)
+      }
     }
 
     if (evaluateId) {

--- a/trmnl-ha/ha-trmnl/screenshot.ts
+++ b/trmnl-ha/ha-trmnl/screenshot.ts
@@ -471,44 +471,50 @@ export class Browser {
         this.#lastRequestedDarkMode = dark
       }
 
-      // Wait strategy: explicit fixed wait OR multi-stage readiness detection
+      // Wait strategy: always run multi-stage readiness detection.
+      // extraWait is an additional tail pad applied AFTER detection — it
+      // covers late WebSocket data and slow renders that the smart signals
+      // can't catch (so users with flaky dashboards can add safety margin
+      // without losing the readiness checks).
       // NOTE: page.goto() already uses waitUntil:'networkidle2' so network is settled
+
+      // Stage 1: Wait for network to re-settle after theme/language changes
+      // Theme and language changes trigger WebSocket messages and cascading renders
+      if (setupResult.themeChanged || setupResult.langChanged) {
+        log.debug`Waiting for network idle after page setup changes`
+        try {
+          await page.waitForNetworkIdle({ idleTime: 500, concurrency: 2 })
+        } catch (_err) {
+          log.debug`Network idle wait timed out after page setup`
+        }
+      }
+
+      // Stage 2: Wait for HA entity data to load (HA pages only)
+      if (!isGenericUrl) {
+        const hassReadyCmd = new WaitForHassReady(page)
+        await hassReadyCmd.call()
+      }
+
+      // Stage 3: Wait for loading indicators to clear
+      const loadingCmd = new WaitForLoadingComplete(page, 15000)
+      const loadingWait = await loadingCmd.call()
+      log.debug`Loading indicators cleared after ${loadingWait}ms`
+
+      // Stage 4: Dismiss notification toasts (HA pages only)
+      if (!isGenericUrl) {
+        const dismissCmd = new DismissToasts(page)
+        const count = await dismissCmd.call()
+        if (count > 0) log.debug`Dismissed ${count} notification toast(s)`
+      }
+
+      // Stage 5: Wait for rendering pipeline to flush
+      const paintCmd = new WaitForPaintStability(page)
+      await paintCmd.call()
+
+      // Stage 6: Optional user-configured tail pad
       if (extraWait && extraWait > 0) {
-        log.debug`Explicit wait: ${extraWait}ms`
+        log.debug`Extra wait pad: ${extraWait}ms`
         await new Promise((resolve) => setTimeout(resolve, extraWait))
-      } else {
-        // Stage 1: Wait for network to re-settle after theme/language changes
-        // Theme and language changes trigger WebSocket messages and cascading renders
-        if (setupResult.themeChanged || setupResult.langChanged) {
-          log.debug`Waiting for network idle after page setup changes`
-          try {
-            await page.waitForNetworkIdle({ idleTime: 500, concurrency: 2 })
-          } catch (_err) {
-            log.debug`Network idle wait timed out after page setup`
-          }
-        }
-
-        // Stage 2: Wait for HA entity data to load (HA pages only)
-        if (!isGenericUrl) {
-          const hassReadyCmd = new WaitForHassReady(page)
-          await hassReadyCmd.call()
-        }
-
-        // Stage 3: Wait for loading indicators to clear
-        const loadingCmd = new WaitForLoadingComplete(page, 15000)
-        const loadingWait = await loadingCmd.call()
-        log.debug`Loading indicators cleared after ${loadingWait}ms`
-
-        // Stage 4: Dismiss notification toasts (HA pages only)
-        if (!isGenericUrl) {
-          const dismissCmd = new DismissToasts(page)
-          const count = await dismissCmd.call()
-          if (count > 0) log.debug`Dismissed ${count} notification toast(s)`
-        }
-
-        // Stage 5: Wait for rendering pipeline to flush
-        const paintCmd = new WaitForPaintStability(page)
-        await paintCmd.call()
       }
 
       return { time: Date.now() - start }

--- a/trmnl-ha/ha-trmnl/screenshot.ts
+++ b/trmnl-ha/ha-trmnl/screenshot.ts
@@ -16,7 +16,12 @@
  */
 
 import puppeteer from 'puppeteer'
-import type { Browser as PuppeteerBrowser, Page, Viewport } from 'puppeteer'
+import type {
+  Browser as PuppeteerBrowser,
+  ConsoleMessage,
+  Page,
+  Viewport,
+} from 'puppeteer'
 import {
   debugLogging as defaultDebugLogging,
   chromiumExecutable as defaultChromiumExecutable,
@@ -411,7 +416,48 @@ export class Browser {
    * If targetUrl is provided, navigates directly to that URL (generic mode).
    * Otherwise, resolves pagePath against the configured base URL (HA mode).
    */
-  async navigatePage({
+  async navigatePage(params: NavigateParams): Promise<NavigateResult> {
+    if (this.#busy) throw new Error('Browser is busy')
+
+    const start = Date.now()
+    this.#busy = true
+
+    try {
+      // home-assistant-js-websocket's subscribeMessage() has a microtask race
+      // between handler registration and incoming WS frames. When the server's
+      // response arrives faster than the registration microtask completes
+      // (notably on cold cache where RTT is ~15ms vs ~38ms warm), HA logs
+      // "Received event for unknown subscription N. Unsubscribing." and drops
+      // the forecast/render-template data. The card never re-subscribes, so
+      // forecast renders empty.
+      //
+      // Retry once with a fresh page when this happens. By the second attempt
+      // the cache is warm enough that response latency exceeds registration
+      // latency, and the subscription holds.
+      const MAX_ATTEMPTS = 2
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        const orphaned = await this.#runNavigationAttempt(params)
+        if (!orphaned || attempt === MAX_ATTEMPTS) {
+          return { time: Date.now() - start }
+        }
+        log.info`HA WS subscription race detected on attempt ${attempt}; retrying navigation with fresh page`
+      }
+      // Loop always returns or throws; this is unreachable.
+      return { time: Date.now() - start }
+    } finally {
+      this.#busy = false
+    }
+  }
+
+  /**
+   * Runs a single navigation attempt and reports whether the HA WS
+   * subscription race was observed during the run. Throws on hard errors
+   * (browser crash, navigation failure) so the retry loop does not mask them.
+   *
+   * @returns true if a "Received event for unknown subscription" console
+   *   warning fired during this attempt (callable race), false otherwise.
+   */
+  async #runNavigationAttempt({
     pagePath,
     targetUrl,
     viewport,
@@ -420,11 +466,11 @@ export class Browser {
     lang,
     theme,
     dark,
-  }: NavigateParams): Promise<NavigateResult> {
-    if (this.#busy) throw new Error('Browser is busy')
+  }: NavigateParams): Promise<boolean> {
+    let orphanDetected = false
+    let consoleHandler: ((msg: ConsoleMessage) => void) | undefined
+    let listeningPage: Page | undefined
 
-    const start = Date.now()
-    this.#busy = true
     try {
       // Fresh page per request: close existing page to eliminate accumulated
       // stale state (WebSocket connections, cached renders, component state)
@@ -432,6 +478,24 @@ export class Browser {
 
       const page = await this.#getPage()
       await page.setViewport(viewport)
+
+      // Listen for the orphaned-subscription console warning that signals
+      // the HA WS subscribeMessage race. Attaching here (after #getPage)
+      // catches warnings from the entire navigation, including card-mount
+      // subscribes triggered by pushState.
+      consoleHandler = (msg) => {
+        // Puppeteer 24+ returns 'warn'; older versions returned 'warning'.
+        // Accept both so we don't break if puppeteer's enum shifts again.
+        const type = msg.type()
+        if (
+          (type === 'warn' || type === 'warning') &&
+          msg.text().includes('Received event for unknown subscription')
+        ) {
+          orphanDetected = true
+        }
+      }
+      page.on('console', consoleHandler)
+      listeningPage = page
 
       // Always first navigation on fresh page - injects auth + full page.goto()
       const authStorage = this.#buildAuthStorage()
@@ -511,7 +575,7 @@ export class Browser {
         await paintCmd.call()
       }
 
-      return { time: Date.now() - start }
+      return orphanDetected
     } catch (err) {
       this.#pageErrorDetected = false
 
@@ -533,7 +597,15 @@ export class Browser {
 
       throw err
     } finally {
-      this.#busy = false
+      // Detach the orphan listener so listeners don't accumulate across
+      // retries / subsequent screenshots. Page may be closed already; ignore.
+      if (consoleHandler && listeningPage) {
+        try {
+          listeningPage.off('console', consoleHandler)
+        } catch (_err) {
+          /* page closed */
+        }
+      }
     }
   }
 

--- a/trmnl-ha/ha-trmnl/screenshot.ts
+++ b/trmnl-ha/ha-trmnl/screenshot.ts
@@ -431,17 +431,22 @@ export class Browser {
       // the forecast/render-template data. The card never re-subscribes, so
       // forecast renders empty.
       //
-      // Retry with a fresh page when this happens. Each subsequent attempt
-      // benefits from a warmer V8 / disk cache so the registration microtask
-      // wins. On slower hardware (e.g. Raspberry Pi 4) the race can lose
-      // more than once in a row, so allow up to MAX_ATTEMPTS - 1 retries.
+      // Retry strategy on detection:
+      //   - Attempt 1 is always a full fresh-page navigation (the per-request
+      //     reset that issue #34 mandates).
+      //   - Attempts 2..N reuse the live page and re-mount the panel via an
+      //     in-app router transition (pushState to '/', then back to the
+      //     target). The WebSocket connection stays open and the JS heap
+      //     stays hot, which is what actually makes the race stop losing.
+      //     Closing and re-creating the page on each retry threw away the
+      //     warmth we needed.
       //
       // Cost is paid only on attempts that detect the orphan warning;
       // dashboards built from REST/static cards (no subscribeMessage calls)
       // never trigger the retry path.
       const MAX_ATTEMPTS = 5
       for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-        const orphaned = await this.#runNavigationAttempt(params)
+        const orphaned = await this.#runNavigationAttempt(params, attempt === 1)
         if (!orphaned) {
           return { time: Date.now() - start }
         }
@@ -449,7 +454,7 @@ export class Browser {
           log.warn`HA WS subscription race persisted after ${MAX_ATTEMPTS} attempts; some card data may be missing from this screenshot`
           return { time: Date.now() - start }
         }
-        log.info`HA WS subscription race detected on attempt ${attempt}; retrying navigation with fresh page`
+        log.info`HA WS subscription race detected on attempt ${attempt}; soft-retrying via in-page router transition`
       }
       // Loop always returns or throws; this is unreachable.
       return { time: Date.now() - start }
@@ -463,30 +468,40 @@ export class Browser {
    * subscription race was observed during the run. Throws on hard errors
    * (browser crash, navigation failure) so the retry loop does not mask them.
    *
+   * @param freshPage true to discard the current page and do a full
+   *   page.goto() (the per-request reset); false to reuse the live page and
+   *   re-mount the panel via an in-app router transition (used by retries).
    * @returns true if a "Received event for unknown subscription" console
    *   warning fired during this attempt (callable race), false otherwise.
    */
-  async #runNavigationAttempt({
-    pagePath,
-    targetUrl,
-    viewport,
-    extraWait,
-    zoom = 1,
-    lang,
-    theme,
-    dark,
-  }: NavigateParams): Promise<boolean> {
+  async #runNavigationAttempt(
+    {
+      pagePath,
+      targetUrl,
+      viewport,
+      extraWait,
+      zoom = 1,
+      lang,
+      theme,
+      dark,
+    }: NavigateParams,
+    freshPage: boolean,
+  ): Promise<boolean> {
     let orphanDetected = false
     let consoleHandler: ((msg: ConsoleMessage) => void) | undefined
     let listeningPage: Page | undefined
 
     try {
-      // Fresh page per request: close existing page to eliminate accumulated
-      // stale state (WebSocket connections, cached renders, component state)
-      await this.#closePage()
+      if (freshPage) {
+        // Fresh page per request: close existing page to eliminate accumulated
+        // stale state (WebSocket connections, cached renders, component state)
+        await this.#closePage()
+      }
 
       const page = await this.#getPage()
-      await page.setViewport(viewport)
+      if (freshPage) {
+        await page.setViewport(viewport)
+      }
 
       // Listen for the orphaned-subscription console warning that signals
       // the HA WS subscribeMessage race. Attaching here (after #getPage)
@@ -506,14 +521,20 @@ export class Browser {
       page.on('console', consoleHandler)
       listeningPage = page
 
-      // Always first navigation on fresh page - injects auth + full page.goto()
-      const authStorage = this.#buildAuthStorage()
-      const navigateCmd = new NavigateToPage(
-        page,
-        authStorage,
-        this.#homeAssistantUrl,
-      )
-      await navigateCmd.call(pagePath, targetUrl)
+      if (freshPage) {
+        // First attempt: full fresh navigation — injects auth, full page.goto()
+        const authStorage = this.#buildAuthStorage()
+        const navigateCmd = new NavigateToPage(
+          page,
+          authStorage,
+          this.#homeAssistantUrl,
+        )
+        await navigateCmd.call(pagePath, targetUrl)
+      } else {
+        // Warm retry: re-mount the panel via SPA pushState on the live page.
+        // WS connection, JS heap, and auth all carry over from attempt 1.
+        await this.#softReroute(page, pagePath, targetUrl)
+      }
 
       // Check if we landed on HA login/auth page (indicates invalid token)
       const currentUrl = page.url()
@@ -616,6 +637,42 @@ export class Browser {
         }
       }
     }
+  }
+
+  /**
+   * Re-mounts the panel on the live page by routing to '/' and then back to
+   * the target path via pushState + popstate. Used by retries instead of a
+   * fresh page.goto() so the existing WebSocket connection and JS heap are
+   * preserved — those are the actual carriers of "warmth" that win the
+   * subscribeMessage race on slow hardware.
+   */
+  async #softReroute(
+    page: Page,
+    pagePath: string,
+    targetUrl?: string,
+  ): Promise<void> {
+    const pageUrl =
+      targetUrl || new URL(pagePath, this.#homeAssistantUrl).toString()
+    const u = new URL(pageUrl)
+    const targetPath = u.pathname + u.search
+
+    // Unmount the current panel by routing to '/'
+    await page.evaluate(() => {
+      history.pushState(null, '', '/')
+      window.dispatchEvent(new PopStateEvent('popstate'))
+    })
+
+    // Brief settle so HA's partial-panel-resolver tears down the panel
+    // before we route back. Without this, the back-transition can merge
+    // with the unmount and skip a full remount cycle.
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    // Route back to the target path; cards re-mount and re-subscribe on
+    // top of the live connection.
+    await page.evaluate((path: string) => {
+      history.pushState(null, '', path)
+      window.dispatchEvent(new PopStateEvent('popstate'))
+    }, targetPath)
   }
 
   /**

--- a/trmnl-ha/ha-trmnl/screenshot.ts
+++ b/trmnl-ha/ha-trmnl/screenshot.ts
@@ -471,50 +471,44 @@ export class Browser {
         this.#lastRequestedDarkMode = dark
       }
 
-      // Wait strategy: always run multi-stage readiness detection.
-      // extraWait is an additional tail pad applied AFTER detection — it
-      // covers late WebSocket data and slow renders that the smart signals
-      // can't catch (so users with flaky dashboards can add safety margin
-      // without losing the readiness checks).
+      // Wait strategy: explicit fixed wait OR multi-stage readiness detection
       // NOTE: page.goto() already uses waitUntil:'networkidle2' so network is settled
-
-      // Stage 1: Wait for network to re-settle after theme/language changes
-      // Theme and language changes trigger WebSocket messages and cascading renders
-      if (setupResult.themeChanged || setupResult.langChanged) {
-        log.debug`Waiting for network idle after page setup changes`
-        try {
-          await page.waitForNetworkIdle({ idleTime: 500, concurrency: 2 })
-        } catch (_err) {
-          log.debug`Network idle wait timed out after page setup`
-        }
-      }
-
-      // Stage 2: Wait for HA entity data to load (HA pages only)
-      if (!isGenericUrl) {
-        const hassReadyCmd = new WaitForHassReady(page)
-        await hassReadyCmd.call()
-      }
-
-      // Stage 3: Wait for loading indicators to clear
-      const loadingCmd = new WaitForLoadingComplete(page, 15000)
-      const loadingWait = await loadingCmd.call()
-      log.debug`Loading indicators cleared after ${loadingWait}ms`
-
-      // Stage 4: Dismiss notification toasts (HA pages only)
-      if (!isGenericUrl) {
-        const dismissCmd = new DismissToasts(page)
-        const count = await dismissCmd.call()
-        if (count > 0) log.debug`Dismissed ${count} notification toast(s)`
-      }
-
-      // Stage 5: Wait for rendering pipeline to flush
-      const paintCmd = new WaitForPaintStability(page)
-      await paintCmd.call()
-
-      // Stage 6: Optional user-configured tail pad
       if (extraWait && extraWait > 0) {
-        log.debug`Extra wait pad: ${extraWait}ms`
+        log.debug`Explicit wait: ${extraWait}ms`
         await new Promise((resolve) => setTimeout(resolve, extraWait))
+      } else {
+        // Stage 1: Wait for network to re-settle after theme/language changes
+        // Theme and language changes trigger WebSocket messages and cascading renders
+        if (setupResult.themeChanged || setupResult.langChanged) {
+          log.debug`Waiting for network idle after page setup changes`
+          try {
+            await page.waitForNetworkIdle({ idleTime: 500, concurrency: 2 })
+          } catch (_err) {
+            log.debug`Network idle wait timed out after page setup`
+          }
+        }
+
+        // Stage 2: Wait for HA entity data to load (HA pages only)
+        if (!isGenericUrl) {
+          const hassReadyCmd = new WaitForHassReady(page)
+          await hassReadyCmd.call()
+        }
+
+        // Stage 3: Wait for loading indicators to clear
+        const loadingCmd = new WaitForLoadingComplete(page, 15000)
+        const loadingWait = await loadingCmd.call()
+        log.debug`Loading indicators cleared after ${loadingWait}ms`
+
+        // Stage 4: Dismiss notification toasts (HA pages only)
+        if (!isGenericUrl) {
+          const dismissCmd = new DismissToasts(page)
+          const count = await dismissCmd.call()
+          if (count > 0) log.debug`Dismissed ${count} notification toast(s)`
+        }
+
+        // Stage 5: Wait for rendering pipeline to flush
+        const paintCmd = new WaitForPaintStability(page)
+        await paintCmd.call()
       }
 
       return { time: Date.now() - start }

--- a/trmnl-ha/ha-trmnl/screenshot.ts
+++ b/trmnl-ha/ha-trmnl/screenshot.ts
@@ -431,13 +431,22 @@ export class Browser {
       // the forecast/render-template data. The card never re-subscribes, so
       // forecast renders empty.
       //
-      // Retry once with a fresh page when this happens. By the second attempt
-      // the cache is warm enough that response latency exceeds registration
-      // latency, and the subscription holds.
-      const MAX_ATTEMPTS = 2
+      // Retry with a fresh page when this happens. Each subsequent attempt
+      // benefits from a warmer V8 / disk cache so the registration microtask
+      // wins. On slower hardware (e.g. Raspberry Pi 4) the race can lose
+      // more than once in a row, so allow up to MAX_ATTEMPTS - 1 retries.
+      //
+      // Cost is paid only on attempts that detect the orphan warning;
+      // dashboards built from REST/static cards (no subscribeMessage calls)
+      // never trigger the retry path.
+      const MAX_ATTEMPTS = 5
       for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
         const orphaned = await this.#runNavigationAttempt(params)
-        if (!orphaned || attempt === MAX_ATTEMPTS) {
+        if (!orphaned) {
+          return { time: Date.now() - start }
+        }
+        if (attempt === MAX_ATTEMPTS) {
+          log.warn`HA WS subscription race persisted after ${MAX_ATTEMPTS} attempts; some card data may be missing from this screenshot`
           return { time: Date.now() - start }
         }
         log.info`HA WS subscription race detected on attempt ${attempt}; retrying navigation with fresh page`

--- a/trmnl-ha/ha-trmnl/tests/unit/navigation-commands.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/navigation-commands.test.ts
@@ -200,7 +200,11 @@ describe('NavigateToPage', () => {
   // ==========================================================================
 
   describe('navigation', () => {
-    it('always uses page.goto', async () => {
+    it('two-step nav for HA non-root URLs: hard-load root then client-side transition', async () => {
+      // Cold-loading directly into a dashboard URL races dashboard-config
+      // arrival with card mount and drops async WebSocket subscriptions
+      // (e.g. weather/subscribe_forecast). The two-step flow re-mounts via
+      // HA's router so subscriptions fire deterministically.
       const nav = new NavigateToPage(
         mockPage,
         STUB_AUTH,
@@ -209,9 +213,46 @@ describe('NavigateToPage', () => {
 
       await nav.call('/lovelace/kitchen')
 
-      expect(mockPage.calls.goto).toEqual([
+      expect(mockPage.calls.goto).toEqual(['http://homeassistant:8123/'])
+      expect(mockPage.calls.waitForFunction).toBe(1)
+      expect(mockPage.calls.evaluate).toHaveLength(1)
+      expect(mockPage.calls.evaluate[0]?.args[0]).toBe('/lovelace/kitchen')
+    })
+
+    it('skips two-step for HA root URL', async () => {
+      const nav = new NavigateToPage(
+        mockPage,
+        STUB_AUTH,
+        'http://homeassistant:8123',
+      )
+
+      await nav.call('/')
+
+      expect(mockPage.calls.goto).toEqual(['http://homeassistant:8123/'])
+      expect(mockPage.calls.waitForFunction).toBe(0)
+      expect(mockPage.calls.evaluate).toHaveLength(0)
+    })
+
+    it('falls back to direct goto when two-step waitForFunction times out', async () => {
+      // If HA never bootstraps (e.g. waitForFunction times out), the two-step
+      // path is unsafe to complete — fall back to a single direct goto so
+      // navigation still produces a result rather than throwing.
+      const flakyPage = createMockPage({
+        waitForFunctionError: new Error('Waiting for function timed out'),
+      })
+      const nav = new NavigateToPage(
+        flakyPage,
+        STUB_AUTH,
+        'http://homeassistant:8123',
+      )
+
+      await nav.call('/lovelace/kitchen')
+
+      expect(flakyPage.calls.goto).toEqual([
+        'http://homeassistant:8123/',
         'http://homeassistant:8123/lovelace/kitchen',
       ])
+      expect(flakyPage.calls.evaluate).toHaveLength(0)
     })
 
     it('uses targetUrl directly when provided', async () => {

--- a/trmnl-ha/ha-trmnl/tests/unit/screenshot-clip.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/screenshot-clip.test.ts
@@ -306,8 +306,10 @@ describe('Browser', () => {
     // home-assistant-js-websocket has a microtask race between subscribe
     // handler registration and incoming WS frames. When triggered, HA logs
     // "Received event for unknown subscription N" and drops forecast data.
-    // The orphan-detector listens for these warnings and retries once with
-    // a fresh page so the warm-cache attempt avoids the race.
+    // The orphan-detector listens for these warnings and retries by re-mounting
+    // the panel via in-page SPA pushState on the same live page (warm WS
+    // connection + warm JS heap is what wins the race on slow hardware).
+    // Attempt 1 is always a fresh page.goto(); attempts 2..N reuse the page.
     // ------------------------------------------------------------------------
 
     describe('retry on WS subscription race', () => {
@@ -321,12 +323,10 @@ describe('Browser', () => {
         )
       })
 
-      // Test helper: wrap a fresh page's goto() so it fires a chosen console
-      // warning AFTER the navigation handler has been attached. goto() is
-      // called from inside NavigateToPage well after #runNavigationAttempt
-      // has registered its orphan listener, so the message reaches the
-      // listener synchronously.
-      function makePageWithConsoleTrigger(
+      // Wrap a fresh page's goto() so it fires a chosen console warning AFTER
+      // the navigation handler has been attached. Used to trigger the orphan
+      // on attempt 1 (the only attempt that calls goto).
+      function makePageWithGotoTrigger(
         text: string,
         type: string = 'warn',
       ): MockPage {
@@ -340,18 +340,38 @@ describe('Browser', () => {
         return page
       }
 
-      it('retries the navigation once when an orphan warning fires', async () => {
+      // Wrap both goto() and evaluate() so the orphan warning fires on
+      // attempt 1 (via goto) AND every soft-retry (via softReroute's
+      // pushState evaluate calls). Used to exercise the MAX_ATTEMPTS cap.
+      function makePagePersistentlyOrphaning(
+        text: string,
+        type: string = 'warn',
+      ): MockPage {
+        const page = makePageWithGotoTrigger(text, type)
+        const origEvaluate = page.evaluate
+        page.evaluate = mock(
+          async (fn: (...args: unknown[]) => unknown, ...args: unknown[]) => {
+            const result = await origEvaluate(fn, ...args)
+            page.fireConsole(text, type)
+            return result
+          },
+        ) as MockFn
+        return page
+      }
+
+      it('soft-retries on the same page when an orphan warning fires', async () => {
         const browser = new Browser(BASE_URL, TOKEN, mockDeps)
         mockBrowserInstance.newPage.mockClear()
 
         let pageCreatedCount = 0
         mockBrowserInstance.newPage.mockImplementation(async () => {
           pageCreatedCount++
-          return pageCreatedCount === 1
-            ? makePageWithConsoleTrigger(
-                'Received event for unknown subscription 42. Unsubscribing.',
-              )
-            : createMockPage()
+          // First (and only) page created: orphans on goto, succeeds on
+          // soft-retry (softReroute uses evaluate, not goto, so the trigger
+          // doesn't re-fire).
+          return makePageWithGotoTrigger(
+            'Received event for unknown subscription 42. Unsubscribing.',
+          )
         })
 
         const result = await browser.navigatePage({
@@ -359,8 +379,10 @@ describe('Browser', () => {
           viewport: DEFAULT_VIEWPORT,
         })
 
-        // Two pages created = first attempt + retry
-        expect(pageCreatedCount).toBe(2)
+        // Soft retry reuses the same page — only one newPage() call total.
+        expect(pageCreatedCount).toBe(1)
+        // goto called exactly once (attempt 1); retry used pushState evaluate.
+        expect(currentMockPage.goto).toHaveBeenCalledTimes(1)
         expect(typeof result.time).toBe('number')
       })
 
@@ -386,14 +408,14 @@ describe('Browser', () => {
         const browser = new Browser(BASE_URL, TOKEN, mockDeps)
         mockBrowserInstance.newPage.mockClear()
 
-        // Every attempt orphans — verify we still return after the cap.
+        // Every attempt orphans (goto on attempt 1, evaluate on each retry).
+        // Verify we still return after the cap and never create extra pages.
         // Cap matches the MAX_ATTEMPTS constant in screenshot.ts (currently 5).
-        const MAX_ATTEMPTS = 5
         let pageCreatedCount = 0
         mockBrowserInstance.newPage.mockImplementation(async () => {
           pageCreatedCount++
-          return makePageWithConsoleTrigger(
-            `Received event for unknown subscription ${pageCreatedCount}. Unsubscribing.`,
+          return makePagePersistentlyOrphaning(
+            'Received event for unknown subscription 1. Unsubscribing.',
           )
         })
 
@@ -402,7 +424,10 @@ describe('Browser', () => {
           viewport: DEFAULT_VIEWPORT,
         })
 
-        expect(pageCreatedCount).toBe(MAX_ATTEMPTS)
+        // Still only one page across all soft retries.
+        expect(pageCreatedCount).toBe(1)
+        // goto called exactly once (only attempt 1 does a hard navigation).
+        expect(currentMockPage.goto).toHaveBeenCalledTimes(1)
         expect(typeof result.time).toBe('number')
       })
 
@@ -413,7 +438,7 @@ describe('Browser', () => {
         let pageCreatedCount = 0
         mockBrowserInstance.newPage.mockImplementation(async () => {
           pageCreatedCount++
-          return makePageWithConsoleTrigger('Some unrelated browser warning')
+          return makePageWithGotoTrigger('Some unrelated browser warning')
         })
 
         await browser.navigatePage({
@@ -426,15 +451,15 @@ describe('Browser', () => {
       })
 
       it('ignores orphan-like warnings of non-warning type', async () => {
-        // Detector only matches type() === 'warning'. An 'info' or 'log'
-        // message with similar text shouldn't trigger a retry.
+        // Detector only matches type() === 'warn' | 'warning'. An 'info' or
+        // 'log' message with similar text shouldn't trigger a retry.
         const browser = new Browser(BASE_URL, TOKEN, mockDeps)
         mockBrowserInstance.newPage.mockClear()
 
         let pageCreatedCount = 0
         mockBrowserInstance.newPage.mockImplementation(async () => {
           pageCreatedCount++
-          return makePageWithConsoleTrigger(
+          return makePageWithGotoTrigger(
             'Received event for unknown subscription 7. Unsubscribing.',
             'info',
           )
@@ -452,15 +477,11 @@ describe('Browser', () => {
         const browser = new Browser(BASE_URL, TOKEN, mockDeps)
         mockBrowserInstance.newPage.mockClear()
 
-        let pageCreatedCount = 0
-        mockBrowserInstance.newPage.mockImplementation(async () => {
-          pageCreatedCount++
-          return pageCreatedCount === 1
-            ? makePageWithConsoleTrigger(
-                'Received event for unknown subscription 99. Unsubscribing.',
-              )
-            : createMockPage()
-        })
+        mockBrowserInstance.newPage.mockImplementation(async () =>
+          makePageWithGotoTrigger(
+            'Received event for unknown subscription 99. Unsubscribing.',
+          ),
+        )
 
         await browser.navigatePage({
           pagePath: '/lovelace/0',

--- a/trmnl-ha/ha-trmnl/tests/unit/screenshot-clip.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/screenshot-clip.test.ts
@@ -53,7 +53,7 @@ let currentMockPage: MockPage
 function createMockPage(): MockPage {
   // Map from event name to list of handlers. Tests can fire 'console' events
   // via fireConsole() to exercise the orphan-detection retry path.
-  const handlers = new Map<string, Array<(arg: unknown) => void>>()
+  const handlers = new Map<string, ((arg: unknown) => void)[]>()
 
   const page: MockPage = {
     screenshot: mock(

--- a/trmnl-ha/ha-trmnl/tests/unit/screenshot-clip.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/screenshot-clip.test.ts
@@ -382,11 +382,13 @@ describe('Browser', () => {
         expect(pageCreatedCount).toBe(1)
       })
 
-      it('caps retries at one (no infinite loop even on persistent race)', async () => {
+      it('caps retries at MAX_ATTEMPTS (no infinite loop on persistent race)', async () => {
         const browser = new Browser(BASE_URL, TOKEN, mockDeps)
         mockBrowserInstance.newPage.mockClear()
 
-        // Both attempts orphan — verify we still return after 2 pages.
+        // Every attempt orphans — verify we still return after the cap.
+        // Cap matches the MAX_ATTEMPTS constant in screenshot.ts (currently 5).
+        const MAX_ATTEMPTS = 5
         let pageCreatedCount = 0
         mockBrowserInstance.newPage.mockImplementation(async () => {
           pageCreatedCount++
@@ -400,7 +402,7 @@ describe('Browser', () => {
           viewport: DEFAULT_VIEWPORT,
         })
 
-        expect(pageCreatedCount).toBe(2)
+        expect(pageCreatedCount).toBe(MAX_ATTEMPTS)
         expect(typeof result.time).toBe('number')
       })
 

--- a/trmnl-ha/ha-trmnl/tests/unit/screenshot-clip.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/screenshot-clip.test.ts
@@ -16,7 +16,7 @@
  * @module tests/unit/screenshot-clip
  */
 
-import { mock, describe, it, expect, beforeEach } from 'bun:test'
+import { mock, describe, it, expect, beforeEach, afterAll } from 'bun:test'
 import type { BrowserDeps } from '../../screenshot.js'
 
 // Safety: const.ts needs these env vars at module load time (no options-dev.json in CI)
@@ -34,6 +34,7 @@ interface MockPage {
   setViewport: MockFn
   close: MockFn
   on: MockFn
+  off: MockFn
   url: () => string
   waitForNetworkIdle: MockFn
   // Methods required by real NavigateToPage
@@ -43,11 +44,17 @@ interface MockPage {
   // Methods required by real wait commands and page setup strategies
   evaluate: MockFn
   waitForFunction: MockFn
+  /** Test helper: invoke all registered 'console' handlers. */
+  fireConsole: (text: string, type?: string) => void
 }
 
 let currentMockPage: MockPage
 
 function createMockPage(): MockPage {
+  // Map from event name to list of handlers. Tests can fire 'console' events
+  // via fireConsole() to exercise the orphan-detection retry path.
+  const handlers = new Map<string, Array<(arg: unknown) => void>>()
+
   const page: MockPage = {
     screenshot: mock(
       async (_opts?: unknown) =>
@@ -57,8 +64,20 @@ function createMockPage(): MockPage {
     close: mock(async () => {}),
     url: () => 'http://localhost:8123/lovelace',
     waitForNetworkIdle: mock(async () => {}),
-    // on() must return the page for method chaining in #setupPageLogging
-    on: mock(() => page),
+    on: mock((event: string, handler: (arg: unknown) => void) => {
+      const arr = handlers.get(event) ?? []
+      arr.push(handler)
+      handlers.set(event, arr)
+      return page
+    }),
+    off: mock((event: string, handler: (arg: unknown) => void) => {
+      const arr = handlers.get(event)
+      if (arr) {
+        const idx = arr.indexOf(handler)
+        if (idx >= 0) arr.splice(idx, 1)
+      }
+      return page
+    }),
     // NavigateToPage: inject auth → navigate → cleanup
     evaluateOnNewDocument: mock(async () => ({ identifier: 'mock-id' })),
     goto: mock(async () => ({ ok: () => true, status: () => 200 })),
@@ -66,6 +85,11 @@ function createMockPage(): MockPage {
     // Wait commands + page setup strategies
     evaluate: mock(async () => 0),
     waitForFunction: mock(async () => {}),
+    fireConsole: (text: string, type: string = 'warn') => {
+      const msg = { type: () => type, text: () => text }
+      const arr = handlers.get('console') ?? []
+      for (const h of arr) h(msg)
+    },
   }
   currentMockPage = page
   return page
@@ -274,6 +298,175 @@ describe('Browser', () => {
       })
 
       expect(typeof result.time).toBe('number')
+    })
+
+    // ------------------------------------------------------------------------
+    // Retry on HA WS subscribeMessage race
+    //
+    // home-assistant-js-websocket has a microtask race between subscribe
+    // handler registration and incoming WS frames. When triggered, HA logs
+    // "Received event for unknown subscription N" and drops forecast data.
+    // The orphan-detector listens for these warnings and retries once with
+    // a fresh page so the warm-cache attempt avoids the race.
+    // ------------------------------------------------------------------------
+
+    describe('retry on WS subscription race', () => {
+      // These tests override mockBrowserInstance.newPage.mockImplementation
+      // to inject console-warning triggers. Restore the default after the
+      // block so #screenshotPage tests below get plain pages.
+      afterAll(() => {
+        mockBrowserInstance.newPage.mockClear()
+        mockBrowserInstance.newPage.mockImplementation(async () =>
+          createMockPage(),
+        )
+      })
+
+      // Test helper: wrap a fresh page's goto() so it fires a chosen console
+      // warning AFTER the navigation handler has been attached. goto() is
+      // called from inside NavigateToPage well after #runNavigationAttempt
+      // has registered its orphan listener, so the message reaches the
+      // listener synchronously.
+      function makePageWithConsoleTrigger(
+        text: string,
+        type: string = 'warn',
+      ): MockPage {
+        const page = createMockPage()
+        const origGoto = page.goto
+        page.goto = mock(async (url: string) => {
+          const result = await origGoto(url)
+          page.fireConsole(text, type)
+          return result
+        }) as MockFn
+        return page
+      }
+
+      it('retries the navigation once when an orphan warning fires', async () => {
+        const browser = new Browser(BASE_URL, TOKEN, mockDeps)
+        mockBrowserInstance.newPage.mockClear()
+
+        let pageCreatedCount = 0
+        mockBrowserInstance.newPage.mockImplementation(async () => {
+          pageCreatedCount++
+          return pageCreatedCount === 1
+            ? makePageWithConsoleTrigger(
+                'Received event for unknown subscription 42. Unsubscribing.',
+              )
+            : createMockPage()
+        })
+
+        const result = await browser.navigatePage({
+          pagePath: '/lovelace/0',
+          viewport: DEFAULT_VIEWPORT,
+        })
+
+        // Two pages created = first attempt + retry
+        expect(pageCreatedCount).toBe(2)
+        expect(typeof result.time).toBe('number')
+      })
+
+      it('does NOT retry when no orphan warning fires', async () => {
+        const browser = new Browser(BASE_URL, TOKEN, mockDeps)
+        mockBrowserInstance.newPage.mockClear()
+
+        let pageCreatedCount = 0
+        mockBrowserInstance.newPage.mockImplementation(async () => {
+          pageCreatedCount++
+          return createMockPage()
+        })
+
+        await browser.navigatePage({
+          pagePath: '/lovelace/0',
+          viewport: DEFAULT_VIEWPORT,
+        })
+
+        expect(pageCreatedCount).toBe(1)
+      })
+
+      it('caps retries at one (no infinite loop even on persistent race)', async () => {
+        const browser = new Browser(BASE_URL, TOKEN, mockDeps)
+        mockBrowserInstance.newPage.mockClear()
+
+        // Both attempts orphan — verify we still return after 2 pages.
+        let pageCreatedCount = 0
+        mockBrowserInstance.newPage.mockImplementation(async () => {
+          pageCreatedCount++
+          return makePageWithConsoleTrigger(
+            `Received event for unknown subscription ${pageCreatedCount}. Unsubscribing.`,
+          )
+        })
+
+        const result = await browser.navigatePage({
+          pagePath: '/lovelace/0',
+          viewport: DEFAULT_VIEWPORT,
+        })
+
+        expect(pageCreatedCount).toBe(2)
+        expect(typeof result.time).toBe('number')
+      })
+
+      it('ignores non-orphan console warnings', async () => {
+        const browser = new Browser(BASE_URL, TOKEN, mockDeps)
+        mockBrowserInstance.newPage.mockClear()
+
+        let pageCreatedCount = 0
+        mockBrowserInstance.newPage.mockImplementation(async () => {
+          pageCreatedCount++
+          return makePageWithConsoleTrigger('Some unrelated browser warning')
+        })
+
+        await browser.navigatePage({
+          pagePath: '/lovelace/0',
+          viewport: DEFAULT_VIEWPORT,
+        })
+
+        // No retry — only 1 page.
+        expect(pageCreatedCount).toBe(1)
+      })
+
+      it('ignores orphan-like warnings of non-warning type', async () => {
+        // Detector only matches type() === 'warning'. An 'info' or 'log'
+        // message with similar text shouldn't trigger a retry.
+        const browser = new Browser(BASE_URL, TOKEN, mockDeps)
+        mockBrowserInstance.newPage.mockClear()
+
+        let pageCreatedCount = 0
+        mockBrowserInstance.newPage.mockImplementation(async () => {
+          pageCreatedCount++
+          return makePageWithConsoleTrigger(
+            'Received event for unknown subscription 7. Unsubscribing.',
+            'info',
+          )
+        })
+
+        await browser.navigatePage({
+          pagePath: '/lovelace/0',
+          viewport: DEFAULT_VIEWPORT,
+        })
+
+        expect(pageCreatedCount).toBe(1)
+      })
+
+      it('keeps #busy=false after a retried navigation completes', async () => {
+        const browser = new Browser(BASE_URL, TOKEN, mockDeps)
+        mockBrowserInstance.newPage.mockClear()
+
+        let pageCreatedCount = 0
+        mockBrowserInstance.newPage.mockImplementation(async () => {
+          pageCreatedCount++
+          return pageCreatedCount === 1
+            ? makePageWithConsoleTrigger(
+                'Received event for unknown subscription 99. Unsubscribing.',
+              )
+            : createMockPage()
+        })
+
+        await browser.navigatePage({
+          pagePath: '/lovelace/0',
+          viewport: DEFAULT_VIEWPORT,
+        })
+
+        expect(browser.busy).toBe(false)
+      })
     })
   })
 


### PR DESCRIPTION
Hi all,

thanks for creating and sharing this nice tool. I came across an issue where weather forecast data is missing in screenshots most of the time (approx. 9 out of 10 screenshots don't contain weather forecast). The same should apply to any websocket-driven widget. Claude Code helped me identifying and fixing this issue. See below for details.

## Summary

Fixes intermittent missing weather forecast data (and any other async WebSocket-loaded widget) in dashboard screenshots. Combines a two-step navigation — so cards mount during an in-app router transition rather than at SPA bootstrap — with a retry safety net that re-mounts the panel on the live page when the `home-assistant-js-websocket` subscription race is observed, preserving the warm WebSocket connection and JS heap that is what actually wins the race on slow hardware.

## Background

Starting with **Home Assistant 2023.9**, the weather frontend stopped reading forecast data from the entity's `forecast` attribute and switched to a per-card WebSocket subscription (`weather/subscribe_forecast`). The legacy attribute was deprecated in that release and removed entirely in **2024.4**, so on any modern HA install the forecast rows in `weather-forecast` cards are populated *only* via that subscription.

The subscription is initiated by the card itself when it mounts — it depends on `hass.connection` being live, the entity registry being populated, and the card having received its `_config` from the dashboard. If any of those isn't ready at mount time, the card silently never subscribes, and no amount of waiting later will summon the data.

HA's `connection-mixin.ts` populates `hass` in a documented order over the same WebSocket: (1) `subscribeEntities` → `hass.states`, (2) `subscribeConfig` → `hass.config`, (3) `subscribeEntityRegistryDisplay` → `hass.entities`, (4) `subscribeDeviceRegistry` → `hass.devices`, (5) `subscribeAreaRegistry` → `hass.areas`. The window between these steps and the card's first `hassSubscribe` call is where the original race lived.

## Symptom

In this add-on, forecast rows were initially missing in roughly 9 out of 10 screenshots. The current weather condition (read from the entity state) rendered correctly; only the forecast — i.e. the data that travels through the new subscription — was absent. Increasing the user-configurable `wait` parameter to 10 s did not help, confirming that the data simply wasn't being requested rather than arriving late.

After the first round of fixes (the two-step nav described below), the failure rate dropped dramatically, but ~1 in 20 screenshots still showed the symptom — most consistently the **first** screenshot after a container restart, i.e. on a cold browser cache. A retry safety net was added for that case; on a fast x86 dev machine it brought the success rate to 100 %.

On a slower target (Raspberry Pi 4) the same code path still produced regular `HA WS subscription race persisted after 5 attempts; some card data may be missing from this screenshot` warnings — multiple times per day — with cards rendering empty. Diagnosing why even five retries kept losing the race is what led to the final change in this PR.

## Root Cause

**Primary cause — cold direct navigation.** Puppeteer was issuing a single `page.goto('/dashboard-<dashboard name>')` directly, which is a hard navigation: the SPA bootstraps and lands on the dashboard panel in one shot. In that flow the dashboard config arrives at roughly the same moment the cards mount, so the weather card frequently mounts before its `_config` (or a fully-populated entity registry) is in place — `hassSubscribe` is called once, the necessary state isn't there, and the subscription is silently skipped.

A diagnostic dump of the card's internal state revealed:

|  | Failed | Successful |
|---|---|---|
| `entity` / `entityStateExists` / `supported_features` | identical | identical |
| `_forecastEvent` | undefined (callback never fired) | `{type:"daily", forecast:[…]}` |
| HA router state | clean direct mount | `AbortError: Transition was skipped` |

The successful runs always coincided with HA's router emitting "Transition was skipped" — the signature of an *in-app* navigation that re-mounts the panel after the SPA is already initialised. In that flow, by the time the card mounts, dashboard config and entity registry are already present and the subscription fires reliably.

**Secondary cause — microtask race in `home-assistant-js-websocket`.** Even with the two-step navigation in place, a fraction of cold-cache screenshots still rendered without a forecast. Tracing the WebSocket frames via Chrome DevTools Protocol showed the card *was* sending `weather/subscribe_forecast`, the server *was* responding within ~15 ms, but the HA frontend was logging:

> `Received event for unknown subscription N. Unsubscribing.`

and then sending an unsubscribe message back to the server. The forecast event data was being discarded.

The cause is a microtask-level race inside `subscribeMessage()`: the callback is registered in the connection's command map *after* an `await` (queue drain). On a cold cache, the WebSocket round trip is fast enough (~15 ms) that the server's response arrives *before* the registration microtask completes — so when the lib dispatches the recv frame it finds no handler and treats the message as garbage. On a warm cache the same round trip takes ~38 ms, which is enough for registration to complete first; the subscription holds and the forecast renders.

**Tertiary cause — retries that threw away the warmth they needed.** The original retry strategy closed the existing page on every orphan detection and ran a full `page.goto()` on a brand-new page. The intent was to benefit from a warm V8/disk cache on the second try. On a Pi 4 that was not enough: closing the page discards exactly the things that decide the race — the live WebSocket connection and the in-process JS heap of the running HA app. Each "retry" was therefore almost as cold as the first attempt, and the race could lose all 5 times in a row. The retry budget was being spent re-paying the bootstrap cost instead of warming up the path that matters.

## Fix

For HA URLs that aren't the root, this PR makes three coordinated changes:

1. **Two-step navigation** — replace the single hard navigation with a flow that mirrors the way a user reaches a dashboard from inside the running app:
   1. `page.goto('/')` — load the SPA at root and let it bootstrap.
   2. `waitForFunction` until `hass.states` is populated.
   3. `history.pushState(...) + dispatchEvent(new PopStateEvent('popstate'))` — trigger HA's client-side router to transition to the target dashboard.

   If the two-step path fails for any reason, navigation falls back to the original direct `goto`.

2. **Retry on subscribe-message orphan, reusing the live page** — wrap `navigatePage()` in a retry loop (up to 5 attempts) that attaches a `page.on('console', …)` listener watching for the `Received event for unknown subscription` warning.

   - **Attempt 1** is always a full fresh-page navigation, preserving the per-request reset that issue #34 requires.
   - **Attempts 2..N** keep the existing page and re-mount the panel via an in-app router transition: `pushState('/')` → brief settle → `pushState(targetPath)`. The WebSocket connection stays open and the JS heap stays hot, so the subscription handler is registered into an already-warm runtime where the registration microtask reliably wins.

   A soft retry costs roughly 1–2 s (no goto, no SPA bootstrap, no WebSocket reconnect), so the worst-case retry budget is well under what a single fresh-page retry used to cost.

3. **Hard errors still propagate immediately** — browser crash, navigation timeout, invalid token, etc. are not retried. Only the soft "orphan detected" signal triggers a second attempt.

## Verification

Manual testing against a Home Assistant 2026.5.0 instance with a `hui-weather-forecast-card` plus a mix of custom cards (mini-graph, mushroom, ultra-card, hvv-card, entity-progress, apexcharts):

- **Before any change:** ~1 in 10 screenshots included forecast rows.
- **After two-step nav alone:** ~19 in 20 screenshots correct; residual ~1/20 still showed the symptom, almost always the first request after a container restart.
- **After two-step nav + fresh-page retry (initial version of this PR):** 100 % on a fast x86 dev machine. On a Raspberry Pi 4, the `persisted after 5 attempts` warning still appeared multiple times per day with cards rendering empty (see logs in PR thread).
- **After two-step nav + live-page soft retry (this PR's final version):** forecast present in 100 % of observed screenshots on the same Pi 4 across a full day of scheduled runs. Cold-start request takes ~10 s when the orphan fires (retry adds ~1–2 s); subsequent requests take ~3–5 s with no retry.

The log line `HA WS subscription race detected on attempt N; soft-retrying via in-page router transition` is what you'll see when the race is detected; absence of subsequent retry lines confirms the live-page re-mount won naturally.

Lint, typecheck, and the full unit suite pass. Tests in `tests/unit/screenshot-clip.test.ts` under `'retry on WS subscription race'` cover: soft retry happens on the same page (no new page created), no retry without orphan, retries are capped at `MAX_ATTEMPTS - 1` (4 retries / 5 total attempts), non-orphan warnings are ignored, non-warning-typed messages are ignored, and `#busy` is reset after a retried navigation.