### PR TITLE
Add configurable navigation timeout (fixes #58)

### DIFF
--- a/trmnl-ha/DOCS.md
+++ b/trmnl-ha/DOCS.md
@@ -158,7 +158,7 @@ bun run dev
 | `home_assistant_url` | string | `http://homeassistant:8123` | Base URL (works with any website) |
 | `timezone` | string | (system) | Timezone for scheduled captures (e.g., `America/New_York`) |
 | `keep_browser_open` | bool | `false` | Keep browser alive between requests (faster, more memory) |
-| `navigation_timeout_ms` | int | `60000` | Maximum time in ms puppeteer will wait for a page navigation to complete before erroring. Bump to `90000` or `120000` if your Home Assistant dashboard takes longer than 60s to load on your hardware (e.g. Pi 4 with many custom Lovelace cards). Min `10000`, max `180000`. |
+| `navigation_timeout_ms` | int | `30000` | Maximum time in ms puppeteer will wait for a page navigation to complete before erroring. Matches puppeteer's default; bump to `60000`, `90000`, or `120000` if your Home Assistant dashboard takes longer than 30s to load on your hardware (e.g. Pi 4 with many custom Lovelace cards). Min `10000`, max `180000`. |
 
 > **Timezone Note:** Without a timezone set, scheduled captures run in UTC. Use an [IANA timezone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) like `America/New_York`, `Europe/London`, or `Asia/Tokyo`. Invalid values silently fall back to UTC (check logs for warnings).
 

--- a/trmnl-ha/DOCS.md
+++ b/trmnl-ha/DOCS.md
@@ -158,6 +158,7 @@ bun run dev
 | `home_assistant_url` | string | `http://homeassistant:8123` | Base URL (works with any website) |
 | `timezone` | string | (system) | Timezone for scheduled captures (e.g., `America/New_York`) |
 | `keep_browser_open` | bool | `false` | Keep browser alive between requests (faster, more memory) |
+| `navigation_timeout_ms` | int | `60000` | Maximum time in ms puppeteer will wait for a page navigation to complete before erroring. Bump to `90000` or `120000` if your Home Assistant dashboard takes longer than 60s to load on your hardware (e.g. Pi 4 with many custom Lovelace cards). Min `10000`, max `180000`. |
 
 > **Timezone Note:** Without a timezone set, scheduled captures run in UTC. Use an [IANA timezone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) like `America/New_York`, `Europe/London`, or `Asia/Tokyo`. Invalid values silently fall back to UTC (check logs for warnings).
 

--- a/trmnl-ha/config.yaml
+++ b/trmnl-ha/config.yaml
@@ -39,6 +39,7 @@ options:
   keep_browser_open: false
   debug_logging: false
   server_port: 10000
+  navigation_timeout_ms: 60000
 
 # Schema for options validation
 schema:
@@ -48,6 +49,7 @@ schema:
   keep_browser_open: bool?
   debug_logging: bool?
   server_port: "int(1024,65535)?"
+  navigation_timeout_ms: "int(10000,180000)?"
 
 # Exclude regeneratable data from HA backups
 backup_exclude:

--- a/trmnl-ha/config.yaml
+++ b/trmnl-ha/config.yaml
@@ -39,7 +39,7 @@ options:
   keep_browser_open: false
   debug_logging: false
   server_port: 10000
-  navigation_timeout_ms: 60000
+  navigation_timeout_ms: 30000
 
 # Schema for options validation
 schema:

--- a/trmnl-ha/ha-trmnl/const.ts
+++ b/trmnl-ha/ha-trmnl/const.ts
@@ -135,6 +135,7 @@ const options: Options = {
     process.env['SERVER_PORT'] !== undefined
       ? parseInt(process.env['SERVER_PORT'], 10)
       : fileOptions.server_port,
+  navigation_timeout_ms: fileOptions.navigation_timeout_ms,
 }
 
 // Log configuration source for debugging
@@ -324,6 +325,18 @@ if (
 export const BROWSER_TIMEOUT: number = parseInt(
   process.env['BROWSER_TIMEOUT'] || '60000',
 )
+
+/**
+ * Navigation timeout for page.goto() in milliseconds.
+ * Default 60s (puppeteer's own default of 30s is too short for complex
+ * Home Assistant dashboards on lower-powered hardware like Pi 4).
+ * Configurable via the add-on `navigation_timeout_ms` option or the
+ * NAVIGATION_TIMEOUT environment variable.
+ * Fixes #58.
+ */
+export const NAVIGATION_TIMEOUT: number =
+  options.navigation_timeout_ms ??
+  parseInt(process.env['NAVIGATION_TIMEOUT'] || '60000')
 
 /**
  * Maximum screenshots before proactive browser restart (memory cleanup)

--- a/trmnl-ha/ha-trmnl/const.ts
+++ b/trmnl-ha/ha-trmnl/const.ts
@@ -328,15 +328,15 @@ export const BROWSER_TIMEOUT: number = parseInt(
 
 /**
  * Navigation timeout for page.goto() in milliseconds.
- * Default 60s (puppeteer's own default of 30s is too short for complex
- * Home Assistant dashboards on lower-powered hardware like Pi 4).
- * Configurable via the add-on `navigation_timeout_ms` option or the
- * NAVIGATION_TIMEOUT environment variable.
+ * Default 30s — matches puppeteer's own default. Bump via the add-on
+ * `navigation_timeout_ms` option or the NAVIGATION_TIMEOUT environment
+ * variable when running complex Home Assistant dashboards on lower-powered
+ * hardware (e.g. Pi 4), where the default may be too short.
  * Fixes #58.
  */
 export const NAVIGATION_TIMEOUT: number =
   options.navigation_timeout_ms ??
-  parseInt(process.env['NAVIGATION_TIMEOUT'] || '60000')
+  parseInt(process.env['NAVIGATION_TIMEOUT'] || '30000')
 
 /**
  * Maximum screenshots before proactive browser restart (memory cleanup)

--- a/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
+++ b/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
@@ -16,6 +16,7 @@ import {
   isAddOn,
   DEFAULT_WAIT_TIME,
   COLD_START_EXTRA_WAIT,
+  NAVIGATION_TIMEOUT,
 } from '../../const.js'
 import { CannotOpenPageError } from '../../error.js'
 import type { NavigationResult } from '../../types/domain.js'
@@ -80,7 +81,10 @@ export class NavigateToPage {
 
     let response
     try {
-      response = await this.#page.goto(pageUrl, { waitUntil: 'networkidle2' })
+      response = await this.#page.goto(pageUrl, {
+        waitUntil: 'networkidle2',
+        timeout: NAVIGATION_TIMEOUT,
+      })
     } catch (err) {
       if (evaluateId) {
         this.#page.removeScriptToEvaluateOnNewDocument(evaluateId.identifier)

--- a/trmnl-ha/ha-trmnl/lib/config-helpers.ts
+++ b/trmnl-ha/ha-trmnl/lib/config-helpers.ts
@@ -18,6 +18,7 @@ export interface Options {
   keep_browser_open?: boolean
   debug_logging?: boolean
   server_port?: number
+  navigation_timeout_ms?: number
 }
 
 /**

--- a/trmnl-ha/ha-trmnl/tests/unit/navigation-commands.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/navigation-commands.test.ts
@@ -30,6 +30,7 @@ interface MockPageCalls {
   evaluateOnNewDocument: number
   removeScriptToEvaluateOnNewDocument: number
   goto: string[]
+  gotoOptions: unknown[]
   evaluate: { fn: unknown; args: unknown[] }[]
   waitForFunction: number
 }
@@ -49,6 +50,7 @@ function createMockPage(
     evaluateOnNewDocument: 0,
     removeScriptToEvaluateOnNewDocument: 0,
     goto: [],
+    gotoOptions: [],
     evaluate: [],
     waitForFunction: 0,
   }
@@ -62,8 +64,9 @@ function createMockPage(
     removeScriptToEvaluateOnNewDocument: async () => {
       calls.removeScriptToEvaluateOnNewDocument++
     },
-    goto: async (url: string, _opts?: unknown) => {
+    goto: async (url: string, opts?: unknown) => {
       calls.goto.push(url)
+      calls.gotoOptions.push(opts)
       if (options.gotoError) throw options.gotoError
       return 'gotoResponse' in options
         ? options.gotoResponse
@@ -250,6 +253,25 @@ describe('NavigateToPage', () => {
       await nav.call('/unused', 'http://external.com/page')
 
       expect(mockPage.calls.removeScriptToEvaluateOnNewDocument).toBe(0)
+    })
+
+    it('passes NAVIGATION_TIMEOUT to page.goto (fixes #58)', async () => {
+      const { NAVIGATION_TIMEOUT } = await import('../../const.js')
+      const nav = new NavigateToPage(
+        mockPage,
+        STUB_AUTH,
+        'http://homeassistant:8123',
+      )
+
+      await nav.call('/lovelace/0')
+
+      expect(mockPage.calls.gotoOptions).toHaveLength(1)
+      const opts = mockPage.calls.gotoOptions[0] as {
+        waitUntil?: string
+        timeout?: number
+      }
+      expect(opts.waitUntil).toBe('networkidle2')
+      expect(opts.timeout).toBe(NAVIGATION_TIMEOUT)
     })
   })
 


### PR DESCRIPTION
## Summary

Fixes #58.

Puppeteer's default `page.goto()` timeout is 30s, which isn't always enough for complex Home Assistant dashboards on slower hardware. Real-world dashboards take 43s+ to finish loading under throttled conditions emulating a Pi 4, so the default 30s aborts navigation before the page is ready.

This PR makes the timeout configurable so users on slow hardware can bump it.

## Changes

- New add-on option `navigation_timeout_ms` in `config.yaml` and the `Options` interface
- New `NAVIGATION_TIMEOUT` env var for standalone/Docker setups
- New `NAVIGATION_TIMEOUT` constant in `const.ts`, passed through to `page.goto()` in `NavigateToPage`
- Default: `30000` (30s), same as puppeteer's default, so existing setups behave identically
- Min: `10000`, max: `180000` (schema-enforced)
- Documented in `DOCS.md` with suggested bumps to 60s/90s/120s for slow hardware

## Backward compatibility

No behavior change for existing users. The default matches puppeteer's existing 30s timeout. Users hitting #58 can set `navigation_timeout_ms: 60000` (or higher) in their add-on config.

## Tests

Added a unit test in `tests/unit/navigation-commands.test.ts` asserting `page.goto` receives the timeout from `NAVIGATION_TIMEOUT`.

## Test plan

- [x] `bun test tests/unit/navigation-commands.test.ts` passes (48 tests including the new one)
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [ ] Verify on a real Pi 4 that bumping the option resolves #58