### PR TITLE
Fix BYOS token expiry, scheduler churn, and settings overwrites

### DIFF
--- a/trmnl-ha/CHANGELOG.md
+++ b/trmnl-ha/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scheduler reload no longer re-registers cron jobs and logs every 60 seconds when schedules are unchanged (#64)
 - Replaced cron jobs are now destroyed instead of stopped, preventing unbounded task accumulation in node-cron's registry
 - Timezone validation no longer warns on valid zone aliases like Etc/UTC, the Docker image's default TZ
+- Device preset selection is now saved on the schedule and restored on every render — it previously reset to "Custom Configuration" immediately, inviting re-picks that overwrote customised viewport, crop, rotation and format values
 ## [0.8.1] - 2026-04-16
 
 ### Added

--- a/trmnl-ha/CHANGELOG.md
+++ b/trmnl-ha/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced cron jobs are now destroyed instead of stopped, preventing unbounded task accumulation in node-cron's registry
 - Timezone validation no longer warns on valid zone aliases like Etc/UTC, the Docker image's default TZ
 - Device preset selection is now saved on the schedule and restored on every render — it previously reset to "Custom Configuration" immediately, inviting re-picks that overwrote customised viewport, crop, rotation and format values
+- BYOS access tokens are refreshed proactively on the scheduler tick. Terminus only accepts refreshes while the 30-minute access token is still valid, so the previous send-time-only refresh failed with 401s for any schedule running less often than every 30 minutes
 ## [0.8.1] - 2026-04-16
 
 ### Added

--- a/trmnl-ha/CHANGELOG.md
+++ b/trmnl-ha/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- BYOS token operations (login, logout, manual save) no longer reset Delivery Mode to legacy or clear the Add-on URL (#62)
+- Scheduler reload no longer re-registers cron jobs and logs every 60 seconds when schedules are unchanged (#64)
+- Replaced cron jobs are now destroyed instead of stopped, preventing unbounded task accumulation in node-cron's registry
+- Timezone validation no longer warns on valid zone aliases like Etc/UTC, the Docker image's default TZ
 ## [0.8.1] - 2026-04-16
 
 ### Added

--- a/trmnl-ha/ha-trmnl/html/js/app.ts
+++ b/trmnl-ha/ha-trmnl/html/js/app.ts
@@ -889,6 +889,10 @@ class App {
       webhook_format: {
         format: 'byos-hanami',
         byosConfig: {
+          // NOTE: Spread existing config first so token updates never drop
+          // fields added after this builder was written (delivery_mode,
+          // addon_base_url) — rebuilding from a hardcoded list caused #62
+          ...existing,
           label: existing?.label || 'Home Assistant',
           name: existing?.name || 'ha-dashboard',
           model_id: existing?.model_id || '1',

--- a/trmnl-ha/ha-trmnl/html/js/app.ts
+++ b/trmnl-ha/ha-trmnl/html/js/app.ts
@@ -128,6 +128,11 @@ class App {
 
       await this.#devicePresetsManager.loadAndRenderPresets()
 
+      // Initial renderUI ran before presets arrived, so the device dropdown
+      // restored against an empty option list — restore again now
+      const active = this.#scheduleManager.activeSchedule
+      if (active) this.#devicePresetsManager.afterDOMRender(active)
+
       const autoRefreshCheckbox = document.getElementById(
         'autoRefreshToggle',
       ) as HTMLInputElement | null
@@ -455,6 +460,10 @@ class App {
         width: parseIntOrDefault(input('s_width'), schedule.viewport.width),
         height: parseIntOrDefault(input('s_height'), schedule.viewport.height),
       },
+      // Persist the device preset so re-renders can restore the selection —
+      // it previously lived only in the DOM and reset to "Custom
+      // Configuration" on every render
+      device: select('devicePreset') || null,
       crop: {
         enabled: checkbox('s_crop_enabled'),
         x: parseIntOrDefault(input('s_crop_x'), 0),

--- a/trmnl-ha/ha-trmnl/html/js/app.ts
+++ b/trmnl-ha/ha-trmnl/html/js/app.ts
@@ -128,8 +128,8 @@ class App {
 
       await this.#devicePresetsManager.loadAndRenderPresets()
 
-      // Initial renderUI ran before presets arrived, so the device dropdown
-      // restored against an empty option list — restore again now
+      // renderUI ran before the async preset fetch resolved, so the device
+      // dropdown restored against an empty option list — restore again now
       const active = this.#scheduleManager.activeSchedule
       if (active) this.#devicePresetsManager.afterDOMRender(active)
 
@@ -460,9 +460,6 @@ class App {
         width: parseIntOrDefault(input('s_width'), schedule.viewport.width),
         height: parseIntOrDefault(input('s_height'), schedule.viewport.height),
       },
-      // Persist the device preset so re-renders can restore the selection —
-      // it previously lived only in the DOM and reset to "Custom
-      // Configuration" on every render
       device: select('devicePreset') || null,
       crop: {
         enabled: checkbox('s_crop_enabled'),
@@ -898,9 +895,6 @@ class App {
       webhook_format: {
         format: 'byos-hanami',
         byosConfig: {
-          // NOTE: Spread existing config first so token updates never drop
-          // fields added after this builder was written (delivery_mode,
-          // addon_base_url) — rebuilding from a hardcoded list caused #62
           ...existing,
           label: existing?.label || 'Home Assistant',
           name: existing?.name || 'ha-dashboard',

--- a/trmnl-ha/ha-trmnl/html/js/device-presets.ts
+++ b/trmnl-ha/ha-trmnl/html/js/device-presets.ts
@@ -98,11 +98,30 @@ export class DevicePresetsManager {
   /**
    * Restores all dropdown state after DOM re-render.
    */
-  afterDOMRender(schedule?: { theme?: string | null }): void {
+  afterDOMRender(schedule?: {
+    theme?: string | null
+    device?: string | null
+  }): void {
     this.renderPresets()
+    this.#restoreDeviceSelection(schedule?.device ?? null)
     this.populateThemePicker(schedule?.theme ?? null)
     this.populateDashboardPicker()
     this.prefillLanguage()
+  }
+
+  /**
+   * Re-selects the schedule's persisted device preset after re-render.
+   * Falls back to "Custom Configuration" when the preset no longer exists.
+   */
+  #restoreDeviceSelection(device: string | null): void {
+    if (!device) return
+    const select = document.getElementById(
+      'devicePreset',
+    ) as HTMLSelectElement | null
+    if (!select) return
+
+    select.value = device
+    if (select.value !== device) select.value = ''
   }
 
   /**

--- a/trmnl-ha/ha-trmnl/lib/config-helpers.ts
+++ b/trmnl-ha/ha-trmnl/lib/config-helpers.ts
@@ -85,11 +85,11 @@ export function findBrowser(): string | undefined {
 export function isValidTimezone(timezone: string): boolean {
   if (Intl.supportedValuesOf('timeZone').includes(timezone)) return true
 
-  // NOTE: supportedValuesOf only lists canonical zone names and omits valid
-  // aliases like Etc/UTC (the Docker image's own default TZ), causing false
-  // warnings on every boot. Accept Area/Location-form zones the runtime can
-  // resolve, while still rejecting abbreviations (EST) and offsets (+05:30)
-  // whose TZ semantics are ambiguous.
+  // supportedValuesOf only lists canonical zone names, omitting valid
+  // aliases like Etc/UTC (the Docker image's default TZ). Accept
+  // Area/Location zones the runtime can resolve while still rejecting
+  // abbreviations (EST) and offsets (+05:30), whose TZ semantics are
+  // ambiguous.
   if (!timezone.includes('/')) return false
   try {
     new Intl.DateTimeFormat(undefined, { timeZone: timezone })

--- a/trmnl-ha/ha-trmnl/lib/config-helpers.ts
+++ b/trmnl-ha/ha-trmnl/lib/config-helpers.ts
@@ -83,8 +83,20 @@ export function findBrowser(): string | undefined {
  * @returns true if timezone is valid IANA timezone name
  */
 export function isValidTimezone(timezone: string): boolean {
-  const validTimezones = Intl.supportedValuesOf('timeZone')
-  return validTimezones.includes(timezone)
+  if (Intl.supportedValuesOf('timeZone').includes(timezone)) return true
+
+  // NOTE: supportedValuesOf only lists canonical zone names and omits valid
+  // aliases like Etc/UTC (the Docker image's own default TZ), causing false
+  // warnings on every boot. Accept Area/Location-form zones the runtime can
+  // resolve, while still rejecting abbreviations (EST) and offsets (+05:30)
+  // whose TZ semantics are ambiguous.
+  if (!timezone.includes('/')) return false
+  try {
+    new Intl.DateTimeFormat(undefined, { timeZone: timezone })
+    return true
+  } catch {
+    return false
+  }
 }
 
 /**

--- a/trmnl-ha/ha-trmnl/lib/scheduler/byos-auth.ts
+++ b/trmnl-ha/ha-trmnl/lib/scheduler/byos-auth.ts
@@ -7,7 +7,11 @@
  * @module lib/scheduler/byos-auth
  */
 
-import type { ByosAuthConfig } from '../../types/domain.js'
+import type {
+  ByosAuthConfig,
+  Schedule,
+  ScheduleUpdate,
+} from '../../types/domain.js'
 import { webhookLogger } from '../logger.js'
 
 const log = webhookLogger()
@@ -26,9 +30,8 @@ const ACCESS_TOKEN_VALIDITY_MS = 25 * 60 * 1000
  * Access token hard expiry on the BYOS server (rodauth's
  * jwt_access_token_period, 1800s by default in Terminus).
  *
- * NOTE: Terminus does not allow refreshing with an expired access token
- * (rodauth allow_refresh_with_expired_jwt_access_token? is false), so once
- * this window passes the only recovery is re-authentication.
+ * NOTE: Stock Terminus rejects refresh requests once the access token has
+ * expired, so past this window the only recovery is re-authentication.
  */
 const ACCESS_TOKEN_EXPIRY_MS = 30 * 60 * 1000
 
@@ -59,6 +62,35 @@ export function isRefreshable(auth: ByosAuthConfig): boolean {
   if (!auth.access_token || !auth.refresh_token || !auth.obtained_at)
     return false
   return Date.now() - auth.obtained_at < ACCESS_TOKEN_EXPIRY_MS
+}
+
+/**
+ * Builds a schedule update that swaps in newly refreshed tokens while
+ * preserving every other byosConfig field.
+ *
+ * @returns Update for persistence, or null when the schedule has no auth
+ */
+export function buildRefreshedAuthUpdate(
+  schedule: Schedule,
+  newTokens: TokenResponse,
+): ScheduleUpdate | null {
+  const byosConfig = schedule.webhook_format?.byosConfig
+  if (!byosConfig?.auth) return null
+
+  return {
+    webhook_format: {
+      ...schedule.webhook_format!,
+      byosConfig: {
+        ...byosConfig,
+        auth: {
+          ...byosConfig.auth,
+          access_token: newTokens.access_token,
+          refresh_token: newTokens.refresh_token,
+          obtained_at: Date.now(),
+        },
+      },
+    },
+  }
 }
 
 /**

--- a/trmnl-ha/ha-trmnl/lib/scheduler/byos-auth.ts
+++ b/trmnl-ha/ha-trmnl/lib/scheduler/byos-auth.ts
@@ -23,6 +23,16 @@ export interface TokenResponse {
 const ACCESS_TOKEN_VALIDITY_MS = 25 * 60 * 1000
 
 /**
+ * Access token hard expiry on the BYOS server (rodauth's
+ * jwt_access_token_period, 1800s by default in Terminus).
+ *
+ * NOTE: Terminus does not allow refreshing with an expired access token
+ * (rodauth allow_refresh_with_expired_jwt_access_token? is false), so once
+ * this window passes the only recovery is re-authentication.
+ */
+const ACCESS_TOKEN_EXPIRY_MS = 30 * 60 * 1000
+
+/**
  * Extracts base URL from webhook URL.
  * e.g., "https://example.com/api/screens" → "https://example.com"
  */
@@ -38,6 +48,17 @@ function isTokenValid(auth: ByosAuthConfig): boolean {
   if (!auth.obtained_at || !auth.access_token) return false
   const elapsed = Date.now() - auth.obtained_at
   return elapsed < ACCESS_TOKEN_VALIDITY_MS
+}
+
+/**
+ * Checks whether stored tokens can still be refreshed. The BYOS server
+ * rejects refresh requests once the access token itself has expired, so
+ * callers should skip refresh attempts (and prompt re-auth) past this window.
+ */
+export function isRefreshable(auth: ByosAuthConfig): boolean {
+  if (!auth.access_token || !auth.refresh_token || !auth.obtained_at)
+    return false
+  return Date.now() - auth.obtained_at < ACCESS_TOKEN_EXPIRY_MS
 }
 
 /**

--- a/trmnl-ha/ha-trmnl/lib/scheduler/cron-job-manager.ts
+++ b/trmnl-ha/ha-trmnl/lib/scheduler/cron-job-manager.ts
@@ -10,7 +10,7 @@
  * Solution: Always stop + recreate jobs on upsert, ensuring fresh closures.
  *
  * NOTE: This module is owned by Scheduler class - don't instantiate directly.
- * NOTE: When modifying upsertJob(), preserve the stop-before-recreate pattern.
+ * NOTE: When modifying upsertJob(), preserve the destroy-before-recreate pattern.
  *
  * @module lib/scheduler/cron-job-manager
  */
@@ -57,10 +57,11 @@ export class CronJobManager {
       return false
     }
 
-    // Always stop existing job to ensure fresh callback with latest data
+    // Destroy existing job (not just stop) so node-cron drops it from its
+    // global registry — stopped tasks otherwise accumulate forever
     const existingJob = this.#jobs.get(schedule.id)
     if (existingJob) {
-      existingJob.stop()
+      existingJob.destroy()
     }
 
     // Create new job with fresh callback
@@ -83,7 +84,7 @@ export class CronJobManager {
   removeJob(id: string, name?: string): boolean {
     const job = this.#jobs.get(id)
     if (job) {
-      job.stop()
+      job.destroy()
       this.#jobs.delete(id)
       const logName = name ? name : id
       log.info`Stopped job: ${logName}`
@@ -102,7 +103,7 @@ export class CronJobManager {
     let prunedCount = 0
     for (const [id, job] of this.#jobs) {
       if (!activeIds.has(id)) {
-        job.stop()
+        job.destroy()
         this.#jobs.delete(id)
         log.info`Removed deleted schedule job: ${id}`
         prunedCount++
@@ -116,7 +117,7 @@ export class CronJobManager {
    */
   stopAll(): void {
     for (const [_id, job] of this.#jobs) {
-      job.stop()
+      job.destroy()
     }
     this.#jobs.clear()
   }

--- a/trmnl-ha/ha-trmnl/lib/scheduler/schedule-executor.ts
+++ b/trmnl-ha/ha-trmnl/lib/scheduler/schedule-executor.ts
@@ -22,6 +22,7 @@ import {
   isSchedulerNetworkError,
 } from '../../const.js'
 import { loadSchedules, updateSchedule } from '../scheduleStore.js'
+import { buildRefreshedAuthUpdate } from './byos-auth.js'
 import type {
   Schedule,
   ScreenshotParams,
@@ -177,23 +178,10 @@ export class ScheduleExecutor {
         webhookFormat: schedule.webhook_format,
         screenshotUrl,
         onTokenRefresh: (newTokens) => {
-          const byosConfig = schedule.webhook_format?.byosConfig
-          if (!byosConfig?.auth) return
+          const updates = buildRefreshedAuthUpdate(schedule, newTokens)
+          if (!updates) return
 
-          updateSchedule(schedule.id, {
-            webhook_format: {
-              ...schedule.webhook_format!,
-              byosConfig: {
-                ...byosConfig,
-                auth: {
-                  ...byosConfig.auth,
-                  access_token: newTokens.access_token,
-                  refresh_token: newTokens.refresh_token,
-                  obtained_at: Date.now(),
-                },
-              },
-            },
-          }).catch((err: unknown) => {
+          updateSchedule(schedule.id, updates).catch((err: unknown) => {
             log.error`Failed to persist refreshed BYOS tokens: ${(err as Error).message}`
           })
         },

--- a/trmnl-ha/ha-trmnl/scheduler.ts
+++ b/trmnl-ha/ha-trmnl/scheduler.ts
@@ -29,6 +29,21 @@ import { schedulerLogger } from './lib/logger.js'
 const log = schedulerLogger()
 
 /**
+ * Detects whether loaded schedules differ from the previous reload.
+ *
+ * @param schedules - Schedules loaded from disk this tick
+ * @param lastSnapshot - Serialized snapshot from the previous reload
+ * @returns New snapshot string when changed, null when identical
+ */
+export function changedSnapshot(
+  schedules: Schedule[],
+  lastSnapshot: string,
+): string | null {
+  const snapshot = JSON.stringify(schedules)
+  return snapshot === lastSnapshot ? null : snapshot
+}
+
+/**
  * High-level scheduler orchestrating cron jobs and screenshot execution.
  */
 export class Scheduler {
@@ -36,6 +51,7 @@ export class Scheduler {
   #cronManager: CronJobManager
   #executor: ScheduleExecutor
   #reloadInterval: ReturnType<typeof setInterval> | undefined
+  #lastSnapshot = ''
 
   /**
    * Creates scheduler instance with injected screenshot function.
@@ -101,6 +117,14 @@ export class Scheduler {
    */
   async #loadAndSchedule(): Promise<void> {
     const schedules = await loadSchedules()
+
+    // NOTE: Skip when nothing changed — re-registering cron jobs every reload
+    // tick churned node-cron tasks 1,440x/day per schedule and spammed INFO
+    // logs that made healthy installs look broken (issue #64)
+    const snapshot = changedSnapshot(schedules, this.#lastSnapshot)
+    if (snapshot === null) return
+    this.#lastSnapshot = snapshot
+
     const activeIds = new Set<string>()
     const enabledSchedules = schedules.filter((s) => s.enabled)
 

--- a/trmnl-ha/ha-trmnl/scheduler.ts
+++ b/trmnl-ha/ha-trmnl/scheduler.ts
@@ -19,9 +19,10 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
-import { loadSchedules } from './lib/scheduleStore.js'
+import { loadSchedules, updateSchedule } from './lib/scheduleStore.js'
 import { ScheduleExecutor, type ScreenshotFunction, type ExecutionResult } from './lib/scheduler/schedule-executor.js'
 import { CronJobManager } from './lib/scheduler/cron-job-manager.js'
+import { getValidAccessToken, isRefreshable } from './lib/scheduler/byos-auth.js'
 import { SCHEDULER_RELOAD_INTERVAL_MS, SCHEDULER_OUTPUT_DIR_NAME, DATA_DIR } from './const.js'
 import type { Schedule } from './types/domain.js'
 import { schedulerLogger } from './lib/logger.js'
@@ -52,6 +53,7 @@ export class Scheduler {
   #executor: ScheduleExecutor
   #reloadInterval: ReturnType<typeof setInterval> | undefined
   #lastSnapshot = ''
+  #refreshingTokens = false
 
   /**
    * Creates scheduler instance with injected screenshot function.
@@ -76,10 +78,15 @@ export class Scheduler {
     log.info`Starting scheduler...`
     // Fire-and-forget initial load (errors logged by loadAndSchedule)
     void this.#loadAndSchedule()
+    void this.#keepByosTokensFresh()
 
-    // Reload schedules periodically
+    // Reload schedules periodically; same tick keeps BYOS tokens fresh —
+    // the server only accepts refreshes while the access token (30 min) is
+    // still valid, so send-time refresh alone fails for any schedule whose
+    // interval exceeds the token lifetime
     this.#reloadInterval = setInterval(() => {
       void this.#loadAndSchedule()
+      void this.#keepByosTokensFresh()
     }, SCHEDULER_RELOAD_INTERVAL_MS)
   }
 
@@ -151,6 +158,54 @@ export class Scheduler {
 
     // Remove jobs for deleted schedules (delegates to CronJobManager)
     this.#cronManager.pruneInactiveJobs(activeIds)
+  }
+
+  /**
+   * Proactively refreshes BYOS tokens before they expire (issue #62 thread).
+   *
+   * getValidAccessToken() is a no-op while tokens are fresh (<25 min) and
+   * refreshes in the 25-30 min window, so calling it every reload tick keeps
+   * the single-use refresh chain alive indefinitely. Disabled schedules are
+   * included so paused schedules don't silently lose auth. Tokens past the
+   * 30 min server expiry are skipped — refresh would be rejected, and
+   * retrying every tick would only spam the log; the send path surfaces the
+   * re-auth error.
+   */
+  async #keepByosTokensFresh(): Promise<void> {
+    if (this.#refreshingTokens) return
+    this.#refreshingTokens = true
+    try {
+      const schedules = await loadSchedules()
+      for (const schedule of schedules) {
+        const auth = schedule.webhook_format?.byosConfig?.auth
+        if (!schedule.webhook_url || !auth?.enabled) continue
+        if (!isRefreshable(auth)) continue
+
+        await getValidAccessToken(schedule.webhook_url, auth, (newTokens) => {
+          log.info`Refreshed BYOS tokens for schedule "${schedule.name}"`
+          void updateSchedule(schedule.id, {
+            webhook_format: {
+              ...schedule.webhook_format!,
+              byosConfig: {
+                ...schedule.webhook_format!.byosConfig!,
+                auth: {
+                  ...auth,
+                  access_token: newTokens.access_token,
+                  refresh_token: newTokens.refresh_token,
+                  obtained_at: Date.now(),
+                },
+              },
+            },
+          }).catch((err: unknown) => {
+            log.error`Failed to persist refreshed BYOS tokens: ${(err as Error).message}`
+          })
+        })
+      }
+    } catch (err) {
+      log.error`BYOS token keepalive failed: ${(err as Error).message}`
+    } finally {
+      this.#refreshingTokens = false
+    }
   }
 
   /**

--- a/trmnl-ha/ha-trmnl/scheduler.ts
+++ b/trmnl-ha/ha-trmnl/scheduler.ts
@@ -22,7 +22,11 @@ import path from 'node:path'
 import { loadSchedules, updateSchedule } from './lib/scheduleStore.js'
 import { ScheduleExecutor, type ScreenshotFunction, type ExecutionResult } from './lib/scheduler/schedule-executor.js'
 import { CronJobManager } from './lib/scheduler/cron-job-manager.js'
-import { getValidAccessToken, isRefreshable } from './lib/scheduler/byos-auth.js'
+import {
+  buildRefreshedAuthUpdate,
+  getValidAccessToken,
+  isRefreshable,
+} from './lib/scheduler/byos-auth.js'
 import { SCHEDULER_RELOAD_INTERVAL_MS, SCHEDULER_OUTPUT_DIR_NAME, DATA_DIR } from './const.js'
 import type { Schedule } from './types/domain.js'
 import { schedulerLogger } from './lib/logger.js'
@@ -80,10 +84,10 @@ export class Scheduler {
     void this.#loadAndSchedule()
     void this.#keepByosTokensFresh()
 
-    // Reload schedules periodically; same tick keeps BYOS tokens fresh —
-    // the server only accepts refreshes while the access token (30 min) is
-    // still valid, so send-time refresh alone fails for any schedule whose
-    // interval exceeds the token lifetime
+    // The same tick keeps BYOS tokens fresh: the server only accepts
+    // refreshes while the access token is still valid, so refreshing at
+    // send time alone fails for schedules running less often than the
+    // token lifetime
     this.#reloadInterval = setInterval(() => {
       void this.#loadAndSchedule()
       void this.#keepByosTokensFresh()
@@ -125,9 +129,8 @@ export class Scheduler {
   async #loadAndSchedule(): Promise<void> {
     const schedules = await loadSchedules()
 
-    // NOTE: Skip when nothing changed — re-registering cron jobs every reload
-    // tick churned node-cron tasks 1,440x/day per schedule and spammed INFO
-    // logs that made healthy installs look broken (issue #64)
+    // Re-registering unchanged jobs every tick churns node-cron tasks and
+    // floods the log
     const snapshot = changedSnapshot(schedules, this.#lastSnapshot)
     if (snapshot === null) return
     this.#lastSnapshot = snapshot
@@ -161,15 +164,12 @@ export class Scheduler {
   }
 
   /**
-   * Proactively refreshes BYOS tokens before they expire (issue #62 thread).
+   * Proactively refreshes BYOS tokens before they expire.
    *
-   * getValidAccessToken() is a no-op while tokens are fresh (<25 min) and
-   * refreshes in the 25-30 min window, so calling it every reload tick keeps
-   * the single-use refresh chain alive indefinitely. Disabled schedules are
-   * included so paused schedules don't silently lose auth. Tokens past the
-   * 30 min server expiry are skipped — refresh would be rejected, and
-   * retrying every tick would only spam the log; the send path surfaces the
-   * re-auth error.
+   * Disabled schedules are included so paused schedules keep working auth.
+   * Tokens already past the server's expiry are skipped — the server would
+   * reject the refresh, and the send path surfaces the re-auth error once
+   * instead of every tick.
    */
   async #keepByosTokensFresh(): Promise<void> {
     if (this.#refreshingTokens) return
@@ -183,20 +183,10 @@ export class Scheduler {
 
         await getValidAccessToken(schedule.webhook_url, auth, (newTokens) => {
           log.info`Refreshed BYOS tokens for schedule "${schedule.name}"`
-          void updateSchedule(schedule.id, {
-            webhook_format: {
-              ...schedule.webhook_format!,
-              byosConfig: {
-                ...schedule.webhook_format!.byosConfig!,
-                auth: {
-                  ...auth,
-                  access_token: newTokens.access_token,
-                  refresh_token: newTokens.refresh_token,
-                  obtained_at: Date.now(),
-                },
-              },
-            },
-          }).catch((err: unknown) => {
+          const updates = buildRefreshedAuthUpdate(schedule, newTokens)
+          if (!updates) return
+
+          void updateSchedule(schedule.id, updates).catch((err: unknown) => {
             log.error`Failed to persist refreshed BYOS tokens: ${(err as Error).message}`
           })
         })

--- a/trmnl-ha/ha-trmnl/tests/unit/byos-auth.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/byos-auth.test.ts
@@ -17,6 +17,7 @@ import { describe, it, expect, beforeEach, afterAll, mock } from 'bun:test'
 import {
   getBaseUrl,
   getValidAccessToken,
+  isRefreshable,
   login,
 } from '../../lib/scheduler/byos-auth.js'
 import type { ByosAuthConfig } from '../../types/domain.js'
@@ -85,6 +86,46 @@ describe('byos-auth', () => {
   // -------------------------------------------------------------------------
   // getValidAccessToken — token state logic
   // -------------------------------------------------------------------------
+
+  describe('#isRefreshable', () => {
+    it('returns true while the access token is within its 30 min lifetime', () => {
+      const auth: ByosAuthConfig = {
+        enabled: true,
+        access_token: 'token',
+        refresh_token: 'refresh',
+        obtained_at: Date.now() - 26 * 60 * 1000,
+      }
+
+      expect(isRefreshable(auth)).toBe(true)
+    })
+
+    it('returns false once the access token has expired server-side', () => {
+      const auth: ByosAuthConfig = {
+        enabled: true,
+        access_token: 'token',
+        refresh_token: 'refresh',
+        obtained_at: Date.now() - 31 * 60 * 1000,
+      }
+
+      expect(isRefreshable(auth)).toBe(false)
+    })
+
+    it('returns false when tokens are missing', () => {
+      const auth: ByosAuthConfig = { enabled: true, obtained_at: Date.now() }
+
+      expect(isRefreshable(auth)).toBe(false)
+    })
+
+    it('returns false when obtained_at is missing', () => {
+      const auth: ByosAuthConfig = {
+        enabled: true,
+        access_token: 'token',
+        refresh_token: 'refresh',
+      }
+
+      expect(isRefreshable(auth)).toBe(false)
+    })
+  })
 
   describe('#getValidAccessToken', () => {
     it('returns null when no access_token stored', async () => {

--- a/trmnl-ha/ha-trmnl/tests/unit/byos-auth.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/byos-auth.test.ts
@@ -15,12 +15,13 @@
 
 import { describe, it, expect, beforeEach, afterAll, mock } from 'bun:test'
 import {
+  buildRefreshedAuthUpdate,
   getBaseUrl,
   getValidAccessToken,
   isRefreshable,
   login,
 } from '../../lib/scheduler/byos-auth.js'
-import type { ByosAuthConfig } from '../../types/domain.js'
+import type { ByosAuthConfig, Schedule } from '../../types/domain.js'
 
 // ---------------------------------------------------------------------------
 // Fetch mock — scoped to this file, restored in afterAll
@@ -86,6 +87,76 @@ describe('byos-auth', () => {
   // -------------------------------------------------------------------------
   // getValidAccessToken — token state logic
   // -------------------------------------------------------------------------
+
+  describe('#buildRefreshedAuthUpdate', () => {
+    const newTokens = {
+      access_token: 'new-access',
+      refresh_token: 'new-refresh',
+    }
+
+    function buildByosSchedule(): Schedule {
+      return {
+        id: 'schedule-1',
+        webhook_format: {
+          format: 'byos-hanami',
+          byosConfig: {
+            label: 'Home Assistant',
+            name: 'ha-dashboard',
+            model_id: '1',
+            preprocessed: true,
+            delivery_mode: 'uri',
+            addon_base_url: 'http://ha.local:10000',
+            auth: {
+              enabled: true,
+              access_token: 'old-access',
+              refresh_token: 'old-refresh',
+              obtained_at: 1,
+            },
+          },
+        },
+      } as Schedule
+    }
+
+    it('returns null when schedule has no auth config', () => {
+      const schedule = { id: 'schedule-1' } as Schedule
+
+      expect(buildRefreshedAuthUpdate(schedule, newTokens)).toBeNull()
+    })
+
+    it('swaps in the new token pair', () => {
+      const update = buildRefreshedAuthUpdate(buildByosSchedule(), newTokens)
+
+      expect(update?.webhook_format?.byosConfig?.auth).toMatchObject({
+        access_token: 'new-access',
+        refresh_token: 'new-refresh',
+      })
+    })
+
+    it('stamps a fresh obtained_at', () => {
+      const before = Date.now()
+
+      const update = buildRefreshedAuthUpdate(buildByosSchedule(), newTokens)
+
+      expect(
+        update?.webhook_format?.byosConfig?.auth?.obtained_at,
+      ).toBeGreaterThanOrEqual(before)
+    })
+
+    it('preserves delivery configuration', () => {
+      const update = buildRefreshedAuthUpdate(buildByosSchedule(), newTokens)
+
+      expect(update?.webhook_format?.byosConfig).toMatchObject({
+        delivery_mode: 'uri',
+        addon_base_url: 'http://ha.local:10000',
+      })
+    })
+
+    it('preserves auth enablement', () => {
+      const update = buildRefreshedAuthUpdate(buildByosSchedule(), newTokens)
+
+      expect(update?.webhook_format?.byosConfig?.auth?.enabled).toBe(true)
+    })
+  })
 
   describe('#isRefreshable', () => {
     it('returns true while the access token is within its 30 min lifetime', () => {

--- a/trmnl-ha/ha-trmnl/tests/unit/config-helpers.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/config-helpers.test.ts
@@ -55,6 +55,12 @@ describe('isValidTimezone', () => {
     it('accepts Etc/GMT offset format', () => {
       expect(isValidTimezone('Etc/GMT+5')).toBe(true)
     })
+
+    // NOTE: Etc/UTC is the Docker image's default TZ but is absent from
+    // Intl.supportedValuesOf, which only lists canonical zone names
+    it('accepts Etc/UTC alias', () => {
+      expect(isValidTimezone('Etc/UTC')).toBe(true)
+    })
   })
 
   describe('invalid timezone values', () => {

--- a/trmnl-ha/ha-trmnl/tests/unit/config-helpers.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/config-helpers.test.ts
@@ -56,8 +56,8 @@ describe('isValidTimezone', () => {
       expect(isValidTimezone('Etc/GMT+5')).toBe(true)
     })
 
-    // NOTE: Etc/UTC is the Docker image's default TZ but is absent from
-    // Intl.supportedValuesOf, which only lists canonical zone names
+    // Etc/UTC is the Docker image's default TZ; Intl.supportedValuesOf
+    // omits it because it only lists canonical zone names
     it('accepts Etc/UTC alias', () => {
       expect(isValidTimezone('Etc/UTC')).toBe(true)
     })

--- a/trmnl-ha/ha-trmnl/tests/unit/scheduler.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/scheduler.test.ts
@@ -1,9 +1,8 @@
 /**
  * Unit tests for Scheduler change detection.
  *
- * The reload loop uses changedSnapshot() to skip cron re-registration when
- * schedules.json is unchanged — re-registering every tick churned node-cron
- * tasks and spammed INFO logs (issue #64).
+ * changedSnapshot() decides whether the reload loop re-registers cron jobs:
+ * only when schedules.json content actually changed.
  *
  * @module tests/unit/scheduler
  */

--- a/trmnl-ha/ha-trmnl/tests/unit/scheduler.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/scheduler.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for Scheduler change detection.
+ *
+ * The reload loop uses changedSnapshot() to skip cron re-registration when
+ * schedules.json is unchanged — re-registering every tick churned node-cron
+ * tasks and spammed INFO logs (issue #64).
+ *
+ * @module tests/unit/scheduler
+ */
+
+import { describe, it, expect } from 'bun:test'
+import { changedSnapshot } from '../../scheduler.js'
+import type { Schedule } from '../../types/domain.js'
+
+/** Minimal valid Schedule for testing */
+function buildSchedule(overrides: Partial<Schedule> = {}): Schedule {
+  return {
+    id: 'test-id-1',
+    name: 'Test Schedule',
+    enabled: true,
+    cron: '*/30 * * * *',
+    webhook_url: null,
+    ha_mode: true,
+    dashboard_path: '/lovelace/0',
+    viewport: { width: 800, height: 480 },
+    createdAt: '2026-06-12T00:00:00.000Z',
+    updatedAt: '2026-06-12T00:00:00.000Z',
+    ...overrides,
+  } as Schedule
+}
+
+describe('changedSnapshot', () => {
+  it('returns a snapshot on first load', () => {
+    expect(changedSnapshot([buildSchedule()], '')).toBeTypeOf('string')
+  })
+
+  it('returns null when schedules are unchanged', () => {
+    const schedules = [buildSchedule()]
+    const first = changedSnapshot(schedules, '')!
+
+    expect(changedSnapshot(schedules, first)).toBeNull()
+  })
+
+  it('returns null for unchanged content loaded as fresh objects', () => {
+    const first = changedSnapshot([buildSchedule()], '')!
+
+    // Reload parses the file anew each tick — equal content, new identity
+    expect(changedSnapshot([buildSchedule()], first)).toBeNull()
+  })
+
+  it('returns a new snapshot when a field changes', () => {
+    const first = changedSnapshot([buildSchedule()], '')!
+    const edited = [buildSchedule({ cron: '* * * * *' })]
+
+    expect(changedSnapshot(edited, first)).toBeTypeOf('string')
+  })
+
+  it('returns a new snapshot when a schedule is added', () => {
+    const first = changedSnapshot([buildSchedule()], '')!
+    const grown = [buildSchedule(), buildSchedule({ id: 'test-id-2' })]
+
+    expect(changedSnapshot(grown, first)).toBeTypeOf('string')
+  })
+
+  it('returns a new snapshot when all schedules are removed', () => {
+    const first = changedSnapshot([buildSchedule()], '')!
+
+    expect(changedSnapshot([], first)).toBeTypeOf('string')
+  })
+})

--- a/trmnl-ha/ha-trmnl/types/domain.ts
+++ b/trmnl-ha/ha-trmnl/types/domain.ts
@@ -230,6 +230,9 @@ export interface Schedule {
   /** Viewport dimensions */
   viewport: Viewport
 
+  /** Device preset id from devices.json (null = custom configuration) */
+  device?: string | null
+
   /** Crop region configuration */
   crop: CropRegion & { enabled: boolean }
 


### PR DESCRIPTION
A batch of fixes verified against a real HA instance and a live Terminus:

- BYOS token operations (login, logout, manual token save) no longer reset Delivery Mode and clear the Add-on URL. Fixes #62
- BYOS tokens refresh proactively on the scheduler tick. Terminus only accepts refreshes while the access token is still valid, so refreshing only at send time breaks any schedule running less often than every 30 minutes
- The scheduler reload only re-registers cron jobs when schedules.json actually changed, and replaced jobs are destroyed so node-cron stops accumulating dead tasks. Fixes #64
- Device preset selection is saved on the schedule and restored on every render. It used to reset to "Custom Configuration" immediately, and re-picking the device overwrote customised viewport, crop, rotation and format
- Timezone validation accepts valid aliases like Etc/UTC (the Docker image default) instead of warning on every boot