### PR TITLE
Added devcontainer for add-on development

### DIFF
--- a/trmnl-ha/.devcontainer/devcontainer.json
+++ b/trmnl-ha/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+{
+  "name": "TRMNL HA add-on",
+  "image": "ghcr.io/home-assistant/devcontainer:5-apps",
+  "overrideCommand": false,
+  "remoteUser": "vscode",
+  "appPort": ["7123:8123", "7357:4357"],
+  "postStartCommand": "bash devcontainer_bootstrap",
+  "runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged"],
+  "workspaceFolder": "/mnt/supervisor/addons/local/${localWorkspaceFolderBasename}",
+  "workspaceMount": "source=${localWorkspaceFolder},target=${containerWorkspaceFolder},type=bind,consistency=cached",
+  "containerEnv": {
+    "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}",
+    "SUPERVISOR_CHANNEL": "beta"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["timonwong.shellcheck", "esbenp.prettier-vscode"],
+      "settings": {
+        "terminal.integrated.profiles.linux": {
+          "zsh": {
+            "path": "/usr/bin/zsh"
+          }
+        },
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "editor.formatOnPaste": false,
+        "editor.formatOnSave": true,
+        "editor.formatOnType": true,
+        "files.trimTrailingWhitespace": true
+      }
+    }
+  },
+  "mounts": [
+    "type=volume,target=/var/lib/docker",
+    "type=volume,target=/var/lib/containerd",
+    "type=volume,target=/mnt/supervisor",
+    "type=tmpfs,target=/tmp"
+  ]
+}

--- a/trmnl-ha/.vscode/tasks.json
+++ b/trmnl-ha/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Start Home Assistant",
+      "type": "shell",
+      "command": "supervisor_run",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/trmnl-ha/DOCS.md
+++ b/trmnl-ha/DOCS.md
@@ -473,6 +473,7 @@ curl http://localhost:10000/health | jq
 
 - [Bun](https://bun.sh) 1.3.5+
 - Docker (for container testing)
+- [VS Code](https://code.visualstudio.com) with the Dev Containers extension (for the Home Assistant devcontainer)
 
 ### Setup
 
@@ -502,6 +503,16 @@ bun install && bun run dev
 ```bash
 ./scripts/docker-build.sh && ./scripts/docker-run.sh
 ```
+
+### Home Assistant devcontainer (test as a real add-on)
+
+Runs the add-on inside a full Home Assistant + Supervisor, so you can verify the add-on lifecycle, options schema, and Ingress — not just the app in isolation.
+
+1. Open the `trmnl-ha` folder in VS Code and **Reopen in Container** when prompted.
+2. Run the **Start Home Assistant** task (Terminal → Run Task).
+3. Open Home Assistant at [http://localhost:7123](http://localhost:7123); the add-on appears under **Settings → Add-ons** as a local app.
+
+To install your local changes instead of the published image, comment out the `image:` line in `config.yaml` before installing the add-on.
 
 ### Scripts
 


### PR DESCRIPTION
Adds the official Home Assistant devcontainer so the add-on can be developed and tested under a real Supervisor.

- Open the trmnl-ha folder in VS Code and reopen in container, then run the "Start Home Assistant" task
- Home Assistant runs at http://localhost:7123 with the add-on available as a local app
- Comment out the image line in config.yaml to build local changes instead of pulling the published image