### PR TITLE
Quality pass: zombie reaping, BYOS delivery fixes, kiosk params, WS race retry

### DIFF
--- a/trmnl-ha/CHANGELOG.md
+++ b/trmnl-ha/CHANGELOG.md
@@ -7,14 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
-- Orphaned Chromium/crashpad processes are now reaped: the container runs under `tini` as PID 1, so periodic browser restarts no longer accumulate zombie processes (#72)
+- `timestamp_12h` add-on option (`TIMESTAMP_12H` environment variable in standalone) to render the capture-time overlay in 12-hour AM/PM format instead of the 24-hour default (#68)
 
 ### Changed
 
 - Webhook connection failures now name the unreachable host and point at the usual culprit — local hostnames that don't resolve inside the add-on container (#71)
 - The preview's over-50KB warning is now spelled out next to the file size instead of hiding in a hover tooltip — oversized images can crash-loop TRMNL devices (#70)
+
+### Fixed
+
+- Orphaned Chromium/crashpad processes are now reaped: the container runs under `tini` as PID 1, so periodic browser restarts no longer accumulate zombie processes (#72)
+- A failed BYOS token refresh no longer discards the stored access token, which turned a refresh 400 (Terminus rotates refresh tokens on use) into an unauthenticated push and a 401 on nearly every scheduled cycle. The push now falls back to the stored token, which stock Terminus keeps valid (#75)
+- BYOS URI delivery no longer renders every dashboard twice: the URI sent to the BYOS server now points at the capture saved by that run (served at `/output/`), instead of a live screenshot endpoint that triggered a second full Chromium render when fetched (#74)
+- Dashboard paths with query params like Kiosk Mode's `?kiosk` no longer fail with HTTP 400: previews join system params with `&` instead of a second `?`, and unknown query params on screenshot requests are forwarded to the Home Assistant page URL instead of being dropped (#44)
+- WebSocket-driven cards (weather forecasts, render templates) intermittently rendered empty when the HA frontend lost its `subscribeMessage` registration race and discarded the subscription data. Navigation now watches for the orphaned-subscription console warning and soft-retries by re-mounting the panel on the live page, preserving the warm WebSocket connection that wins the race — thanks @michael-fritzsch (#55)
+- "Send Now" on a disabled schedule no longer deletes the capture it just saved when no other schedules are enabled — the retention limit previously computed to zero files
 
 ## [0.9.0] - 2026-06-24
 

--- a/trmnl-ha/CHANGELOG.md
+++ b/trmnl-ha/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Orphaned Chromium/crashpad processes are now reaped: the container runs under `tini` as PID 1, so periodic browser restarts no longer accumulate zombie processes (#72)
 
+### Changed
+
+- Webhook connection failures now name the unreachable host and point at the usual culprit — local hostnames that don't resolve inside the add-on container (#71)
+
 ## [0.9.0] - 2026-06-24
 
 ### Added

--- a/trmnl-ha/CHANGELOG.md
+++ b/trmnl-ha/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Webhook connection failures now name the unreachable host and point at the usual culprit — local hostnames that don't resolve inside the add-on container (#71)
+- The preview's over-50KB warning is now spelled out next to the file size instead of hiding in a hover tooltip — oversized images can crash-loop TRMNL devices (#70)
 
 ## [0.9.0] - 2026-06-24
 

--- a/trmnl-ha/CHANGELOG.md
+++ b/trmnl-ha/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Orphaned Chromium/crashpad processes are now reaped: the container runs under `tini` as PID 1, so periodic browser restarts no longer accumulate zombie processes (#72)
+
 ## [0.9.0] - 2026-06-24
 
 ### Added

--- a/trmnl-ha/DOCS.md
+++ b/trmnl-ha/DOCS.md
@@ -159,6 +159,7 @@ bun run dev
 | `timezone` | string | (system) | Timezone for scheduled captures (e.g., `America/New_York`) |
 | `keep_browser_open` | bool | `false` | Keep browser alive between requests (faster, more memory) |
 | `timestamp_overlay` | bool | `false` | Stamp the capture time in the bottom-right corner of every screenshot. Can also be enabled per schedule ("Show Capture Time") or per request with the `timestamp` URL parameter. |
+| `timestamp_12h` | bool | `false` | Render the capture-time overlay in 12-hour format (`2026-07-16 2:30 PM`) instead of the 24-hour default (`TIMESTAMP_12H` environment variable in standalone). |
 | `navigation_timeout_ms` | int | `30000` | Maximum time in ms puppeteer will wait for a page navigation to complete before erroring. Matches puppeteer's default; bump to `60000`, `90000`, or `120000` if your Home Assistant dashboard takes longer than 30s to load on your hardware (e.g. Pi 4 with many custom Lovelace cards). Min `10000`, max `180000`. |
 
 > **Timezone Note:** Without a timezone set, scheduled captures run in UTC. Use an [IANA timezone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) like `America/New_York`, `Europe/London`, or `Asia/Tokyo`. Invalid values silently fall back to UTC (check logs for warnings).

--- a/trmnl-ha/Dockerfile
+++ b/trmnl-ha/Dockerfile
@@ -53,6 +53,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     # Minimal utilities for health checks and runtime
     curl \
     ca-certificates \
+    # Init process to reap orphaned Chromium children (zombie processes)
+    tini \
     # font support for emoji
     fonts-noto-color-emoji \
     # CJK font support for international dashboards
@@ -124,6 +126,7 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
   CMD curl -f http://localhost:10000/health || exit 1
 
-# Use entrypoint for setup
-ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+# Use entrypoint for setup, wrapped in tini so PID 1 reaps orphaned
+# Chromium/crashpad children (Bun as PID 1 never wait()s them — see #72)
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
 CMD ["bun", "run", "main.js"]

--- a/trmnl-ha/config.yaml
+++ b/trmnl-ha/config.yaml
@@ -41,6 +41,7 @@ options:
   server_port: 10000
   navigation_timeout_ms: 30000
   timestamp_overlay: false
+  timestamp_12h: false
 
 # Schema for options validation
 schema:
@@ -52,6 +53,7 @@ schema:
   server_port: "int(1024,65535)?"
   navigation_timeout_ms: "int(10000,180000)?"
   timestamp_overlay: bool?
+  timestamp_12h: bool?
 
 # Exclude regeneratable data from HA backups
 backup_exclude:

--- a/trmnl-ha/config.yaml
+++ b/trmnl-ha/config.yaml
@@ -7,7 +7,7 @@ image: ghcr.io/usetrmnl/trmnl-ha-{arch}
 # NOTE: Uncomment after setting up Codenotary signing in CI
 # codenotary: dev@usetrmnl.com
 homeassistant_api: true
-init: false
+init: false # Image ships its own init (tini) to reap orphaned Chromium children (#72)
 apparmor: false # TODO: Enable after apparmor is tested. Disabling for now to resolve "audit backlog limit exceeded" warnings
 watchdog: "http://[HOST]:10000/health"
 arch:

--- a/trmnl-ha/ha-trmnl/const.ts
+++ b/trmnl-ha/ha-trmnl/const.ts
@@ -132,6 +132,10 @@ const options: Options = {
     process.env['TIMESTAMP_OVERLAY'] !== undefined
       ? process.env['TIMESTAMP_OVERLAY'] === 'true'
       : fileOptions.timestamp_overlay,
+  timestamp_12h:
+    process.env['TIMESTAMP_12H'] !== undefined
+      ? process.env['TIMESTAMP_12H'] === 'true'
+      : fileOptions.timestamp_12h,
   debug_logging:
     process.env['DEBUG_LOGGING'] !== undefined
       ? process.env['DEBUG_LOGGING'] === 'true'
@@ -292,6 +296,13 @@ export const keepBrowserOpen: boolean = options.keep_browser_open ?? false
  * TIMESTAMP_OVERLAY environment variable.
  */
 export const TIMESTAMP_OVERLAY: boolean = options.timestamp_overlay ?? false
+
+/**
+ * Render the timestamp overlay in 12-hour format (e.g. "2026-07-16 2:30 PM")
+ * instead of the 24-hour default. Set via the timestamp_12h add-on option or
+ * the TIMESTAMP_12H environment variable.
+ */
+export const TIMESTAMP_12H: boolean = options.timestamp_12h ?? false
 
 /**
  * Enable debug logging (from HA add-on configuration)

--- a/trmnl-ha/ha-trmnl/html/js/api-client.ts
+++ b/trmnl-ha/ha-trmnl/html/js/api-client.ts
@@ -210,7 +210,9 @@ export class FetchPreview {
    * Fetches preview image for a schedule
    */
   async call(path: string, params: URLSearchParams): Promise<Blob> {
-    const url = `.${path}?${params.toString()}`
+    // A dashboard path may carry its own query (e.g. /lovelace/0?kiosk)
+    const separator = path.includes('?') ? '&' : '?'
+    const url = `.${path}${separator}${params.toString()}`
     const response = await fetch(url)
 
     if (!response.ok) {

--- a/trmnl-ha/ha-trmnl/html/js/preview-generator.ts
+++ b/trmnl-ha/ha-trmnl/html/js/preview-generator.ts
@@ -111,11 +111,15 @@ export class PreviewGenerator {
       loadTime.textContent = `${Math.round(loadTimeMs)}ms`
     }
 
-    // Display file size with warning if over 50KB
+    // Display file size with warning if over 50KB. The warning is spelled
+    // out inline — a tooltip-only hint was missed and led to devices
+    // crash-looping on oversized images (#70).
     if (fileSize) {
       const sizeKB = (sizeBytes / 1024).toFixed(1)
       const isOverLimit = sizeBytes > 50 * 1024
-      fileSize.textContent = `${sizeKB} KB`
+      fileSize.textContent = isOverLimit
+        ? `${sizeKB} KB — ⚠ exceeds the TRMNL 50KB limit; the device may fail to display it. Reduce dashboard complexity, bit depth, or viewport size.`
+        : `${sizeKB} KB`
       fileSize.className = isOverLimit ? 'text-red-500 font-bold' : 'text-muted'
       fileSize.title = isOverLimit
         ? 'Warning: Image exceeds TRMNL 50KB limit'

--- a/trmnl-ha/ha-trmnl/lib/config-helpers.ts
+++ b/trmnl-ha/ha-trmnl/lib/config-helpers.ts
@@ -17,6 +17,7 @@ export interface Options {
   chromium_executable?: string
   keep_browser_open?: boolean
   timestamp_overlay?: boolean
+  timestamp_12h?: boolean
   debug_logging?: boolean
   server_port?: number
   navigation_timeout_ms?: number

--- a/trmnl-ha/ha-trmnl/lib/dithering.ts
+++ b/trmnl-ha/ha-trmnl/lib/dithering.ts
@@ -16,6 +16,7 @@ const gm = gmLib.subClass({ imageMagick: true })
 import {
   COLOR_PALETTES,
   GRAYSCALE_PALETTES,
+  TIMESTAMP_12H,
   VALID_ROTATIONS,
 } from '../const.js'
 import { FloydSteinbergStrategy } from './dithering/floyd-steinberg-strategy.js'
@@ -352,12 +353,20 @@ export async function processImage(
   return buffer
 }
 
-/** Formats capture time as "YYYY-MM-DD HH:MM" in the configured timezone */
-function formatTimestamp(date: Date): string {
-  return date.toLocaleString('sv-SE', {
-    dateStyle: 'short',
-    timeStyle: 'short',
-  })
+/**
+ * Formats capture time as "YYYY-MM-DD HH:MM" (24h default) or
+ * "YYYY-MM-DD H:MM AM/PM" (timestamp_12h option) in the configured timezone.
+ * Exported for tests; production callers use the configured default.
+ */
+export function formatTimestamp(
+  date: Date,
+  hour12: boolean = TIMESTAMP_12H,
+): string {
+  const datePart = date.toLocaleDateString('sv-SE')
+  const timePart = hour12
+    ? date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+    : date.toLocaleTimeString('sv-SE', { hour: '2-digit', minute: '2-digit' })
+  return `${datePart} ${timePart}`
 }
 
 /**

--- a/trmnl-ha/ha-trmnl/lib/http-router.ts
+++ b/trmnl-ha/ha-trmnl/lib/http-router.ts
@@ -27,7 +27,11 @@ import {
   getBaseUrl as defaultGetBaseUrl,
 } from './scheduler/byos-auth.js'
 import { loadPresets } from '../devices.js'
-import { PALETTE_OPTIONS } from '../const.js'
+import {
+  DATA_DIR,
+  PALETTE_OPTIONS,
+  SCHEDULER_OUTPUT_DIR_NAME,
+} from '../const.js'
 import type { BrowserFacade } from './browserFacade.js'
 import type {
   ScheduleInput,
@@ -56,6 +60,7 @@ const MIME_TYPES: Record<string, string> = {
   gif: 'image/gif',
   svg: 'image/svg+xml',
   ico: 'image/x-icon',
+  bmp: 'image/bmp',
 }
 
 /** Scheduler interface for manual execution */
@@ -80,6 +85,8 @@ export interface HttpRouterDeps {
     password: string,
   ) => Promise<TokenResponse>
   getBaseUrl: (webhookUrl: string) => string
+  /** Directory holding saved scheduler captures, served at /output/ */
+  outputDir: string
 }
 
 const defaultDeps: HttpRouterDeps = {
@@ -89,6 +96,7 @@ const defaultDeps: HttpRouterDeps = {
   deleteSchedule: defaultDeleteSchedule,
   byosLogin: defaultByosLogin,
   getBaseUrl: defaultGetBaseUrl,
+  outputDir: join(DATA_DIR, SCHEDULER_OUTPUT_DIR_NAME),
 }
 
 /**
@@ -192,7 +200,44 @@ export class HttpRouter {
       return this.#handleStaticFile(response, pathname)
     }
 
+    if (pathname.startsWith('/output/')) {
+      return this.#handleOutputFile(response, pathname)
+    }
+
     return false
+  }
+
+  /**
+   * Serves saved scheduler captures so BYOS servers fetch the exact bytes
+   * of a scheduled render instead of triggering a second full render (#74).
+   */
+  async #handleOutputFile(
+    response: ServerResponse,
+    pathname: string,
+  ): Promise<boolean> {
+    const filename = decodeURIComponent(pathname.slice('/output/'.length))
+
+    // Saved filenames are [A-Za-z0-9_] + timestamp + extension; anything
+    // else (path separators, empty) is a traversal attempt.
+    if (!/^[\w.-]+$/.test(filename)) {
+      response.statusCode = 404
+      response.end('Not Found')
+      return true
+    }
+
+    try {
+      const content = await readFile(join(this.#deps.outputDir, filename))
+      const ext = filename.split('.').pop() || ''
+      response.writeHead(200, {
+        'Content-Type': MIME_TYPES[ext] || 'application/octet-stream',
+        'Content-Length': content.length,
+      })
+      response.end(content)
+    } catch {
+      response.statusCode = 404
+      response.end('Not Found')
+    }
+    return true
   }
 
   #handleHealth(response: ServerResponse): boolean {

--- a/trmnl-ha/ha-trmnl/lib/scheduler/byos-auth.ts
+++ b/trmnl-ha/ha-trmnl/lib/scheduler/byos-auth.ts
@@ -32,11 +32,13 @@ export interface TokenResponse {
 const ACCESS_TOKEN_VALIDITY_MS = 10 * 60 * 1000
 
 /**
- * Access token hard expiry on the BYOS server (rodauth's
- * jwt_access_token_period, 1800s by default in Terminus).
+ * Access token hard expiry on the BYOS server when session expiration is
+ * enabled (rodauth's jwt_access_token_period, 1800s). Stock Terminus disables
+ * session expiration and issues ~100-year tokens, so this window only matters
+ * for hardened installs.
  *
- * NOTE: Stock Terminus rejects refresh requests once the access token has
- * expired, so past this window the only recovery is re-authentication.
+ * NOTE: Rodauth rejects refresh requests once the access token has expired,
+ * so past this window the only recovery is re-authentication.
  */
 const ACCESS_TOKEN_EXPIRY_MS = 30 * 60 * 1000
 
@@ -165,13 +167,14 @@ async function refreshToken(
 }
 
 /**
- * Gets a valid access token, refreshing if needed.
- * Returns null if tokens are missing/expired and need re-authentication.
+ * Gets a valid access token, refreshing if needed. A failed refresh falls
+ * back to the stored access token — on stock Terminus it stays valid, and a
+ * push with a genuinely expired token fails no worse than one with none.
  *
  * @param webhookUrl - Full webhook URL (base URL is extracted)
  * @param auth - Stored auth config with tokens
  * @param onTokenRefresh - Callback to save new tokens (called on refresh)
- * @returns Access token or null if re-auth needed
+ * @returns Access token, or null when no tokens are stored (re-auth needed)
  */
 export async function getValidAccessToken(
   webhookUrl: string,
@@ -206,8 +209,13 @@ export async function getValidAccessToken(
 
     return newTokens.access_token
   } catch (err) {
-    // Refresh failed - user needs to re-authenticate
-    log.error`BYOS auth: refresh failed, re-authentication required: ${(err as Error).message}`
-    return null
+    // Rodauth rotates refresh tokens on use, so a concurrent refresh (send
+    // path vs keepalive, each holding its own copy of the auth config) makes
+    // the loser's refresh token invalid → 400. The stored access token is
+    // still valid on the server (stock Terminus tokens live ~100 years, and
+    // even with session expiration enabled it outlives the refresh window),
+    // so use it rather than pushing unauthenticated. See issue #75.
+    log.warn`BYOS auth: refresh failed, falling back to stored access token: ${(err as Error).message}`
+    return auth.access_token
   }
 }

--- a/trmnl-ha/ha-trmnl/lib/scheduler/schedule-executor.ts
+++ b/trmnl-ha/ha-trmnl/lib/scheduler/schedule-executor.ts
@@ -125,8 +125,14 @@ export class ScheduleExecutor {
     log.info`Saved: ${outputPath}`
 
     const schedules = await loadSchedules()
-    const maxFiles =
-      schedules.filter((s) => s.enabled).length * SCHEDULER_RETENTION_MULTIPLIER
+    // Floor at 1: "Send Now" runs disabled schedules too, and with zero
+    // enabled schedules maxFiles would be 0 — deleting the capture we just
+    // saved (and 404ing the BYOS URI fetch that points at it).
+    const enabledCount = Math.max(
+      schedules.filter((s) => s.enabled).length,
+      1,
+    )
+    const maxFiles = enabledCount * SCHEDULER_RETENTION_MULTIPLIER
     const { deletedCount } = cleanupOldScreenshots({
       outputDir: this.#outputDir,
       maxFiles,

--- a/trmnl-ha/ha-trmnl/lib/scheduler/schedule-executor.ts
+++ b/trmnl-ha/ha-trmnl/lib/scheduler/schedule-executor.ts
@@ -13,8 +13,6 @@ import {
   WebhookHttpError,
   buildParams,
 } from './services.js'
-import { resolveScreenshotTarget } from '../../html/shared/screenshot-target.js'
-import { buildScreenshotParams } from '../../html/shared/build-screenshot-params.js'
 import { sleep } from '../sleep.js'
 import {
   SCHEDULER_MAX_RETRIES,
@@ -98,7 +96,7 @@ export class ScheduleExecutor {
   async #executeOnce(schedule: Schedule): Promise<ExecutionResult> {
     const params = buildParams(schedule)
     const imageBuffer = await this.#screenshotFn(params)
-    const savedPath = await this.#saveAndCleanup(
+    const { savedPath, filename } = await this.#saveAndCleanup(
       schedule,
       imageBuffer,
       params.format,
@@ -107,6 +105,7 @@ export class ScheduleExecutor {
       schedule,
       imageBuffer,
       params.format,
+      filename,
     )
     return { success: true, savedPath, webhook }
   }
@@ -116,8 +115,8 @@ export class ScheduleExecutor {
     schedule: Schedule,
     imageBuffer: Buffer,
     format: string,
-  ): Promise<string> {
-    const { outputPath } = saveScreenshot({
+  ): Promise<{ savedPath: string; filename: string }> {
+    const { outputPath, filename } = saveScreenshot({
       outputDir: this.#outputDir,
       scheduleName: schedule.name,
       imageBuffer,
@@ -136,28 +135,24 @@ export class ScheduleExecutor {
 
     if (deletedCount > 0)
       log.debug`Cleanup: Deleted ${deletedCount} old file(s)`
-    return outputPath
+    return { savedPath: outputPath, filename }
   }
 
-  /** Builds the screenshot endpoint URL for BYOS URI mode. Returns undefined when URI mode is not applicable. */
-  #buildScreenshotUrl(schedule: Schedule): string | undefined {
+  /**
+   * Builds the URL for BYOS URI mode, pointing at the capture that was just
+   * saved. The BYOS server used to be sent a live screenshot-endpoint URL,
+   * so its fetch triggered a second full render per update (#74).
+   * Returns undefined when URI mode is not applicable.
+   */
+  #buildScreenshotUrl(
+    schedule: Schedule,
+    filename: string,
+  ): string | undefined {
     const byos = schedule.webhook_format?.byosConfig
     if (!byos?.addon_base_url) return undefined
     if (byos.delivery_mode === 'data') return undefined
 
-    const target = resolveScreenshotTarget(schedule)
-    const params = buildScreenshotParams(schedule)
-
-    // NOTE: In generic mode the router serves the UI at `/` unless `url` is
-    // present in the query. Thread target_url through so Terminus's fetch
-    // hits the screenshot handler instead of the UI HTML.
-    if (!target.isHAMode && target.fullUrl) {
-      params.append('url', target.fullUrl)
-    }
-
-    const path = target.path.replace(/^\//, '')
-
-    return `${byos.addon_base_url.replace(/\/+$/, '')}/${path}?${params.toString()}`
+    return `${byos.addon_base_url.replace(/\/+$/, '')}/output/${encodeURIComponent(filename)}`
   }
 
   /** Uploads to webhook if configured, returns result for UI feedback */
@@ -165,11 +160,12 @@ export class ScheduleExecutor {
     schedule: Schedule,
     imageBuffer: Buffer,
     format: string,
+    filename: string,
   ): Promise<WebhookResult | undefined> {
     if (!schedule.webhook_url) return undefined
 
     const webhookUrl = schedule.webhook_url
-    const screenshotUrl = this.#buildScreenshotUrl(schedule)
+    const screenshotUrl = this.#buildScreenshotUrl(schedule, filename)
 
     try {
       const result = await uploadToWebhook({

--- a/trmnl-ha/ha-trmnl/lib/scheduler/webhook-delivery.ts
+++ b/trmnl-ha/ha-trmnl/lib/scheduler/webhook-delivery.ts
@@ -220,11 +220,23 @@ export async function uploadToWebhook(
     }
   }
 
-  const response = await fetch(webhookUrl, {
-    method: 'POST',
-    headers,
-    body: fetchBody,
-  })
+  let response: Response
+  try {
+    response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers,
+      body: fetchBody,
+    })
+  } catch (err) {
+    // Bun's raw connect errors ("Unable to connect...") don't say which host
+    // failed or why. Most reports trace to hostnames that don't resolve from
+    // inside the add-on container (#71), so name the host and the likely fix.
+    const { hostname } = new URL(webhookUrl)
+    throw new Error(
+      `Could not reach ${hostname}: ${(err as Error).message}. ` +
+        `If ${hostname} is a local hostname, it may not resolve inside the add-on container — try the server's IP address instead.`,
+    )
+  }
 
   const responseText = await response.text()
 

--- a/trmnl-ha/ha-trmnl/lib/screenshot-params-parser.ts
+++ b/trmnl-ha/ha-trmnl/lib/screenshot-params-parser.ts
@@ -19,6 +19,41 @@ import type {
   CompressionLevel,
 } from '../types/domain.js'
 
+/**
+ * Query params consumed by the screenshot pipeline. Anything else is
+ * forwarded to the target page URL so dashboard extras like Kiosk Mode's
+ * `?kiosk` reach Home Assistant instead of being dropped (#44).
+ */
+const SYSTEM_PARAMS = new Set([
+  'viewport',
+  'url',
+  'wait',
+  'zoom',
+  'crop_x',
+  'crop_y',
+  'crop_width',
+  'crop_height',
+  'invert',
+  'timestamp',
+  'format',
+  'rotate',
+  'lang',
+  'theme',
+  'dark',
+  'next',
+  'dithering',
+  'dither_method',
+  'palette',
+  'no_gamma',
+  'levels_enabled',
+  'black_level',
+  'white_level',
+  'no_normalize',
+  'saturation_boost',
+  'bit_depth',
+  'compression_level',
+])
+
 /** Parsed screenshot parameters */
 export interface ParsedScreenshotParams {
   pagePath: string
@@ -57,12 +92,30 @@ export class ScreenshotParamsParser {
     const targetUrl = requestUrl.searchParams.get('url') || undefined
 
     return {
-      pagePath: requestUrl.pathname,
+      pagePath: this.#buildPagePath(requestUrl),
       targetUrl,
       viewport,
       ...this.#parseProcessing(requestUrl),
       ...this.#parseDithering(requestUrl),
     }
+  }
+
+  /**
+   * Appends non-system query params to the page path so they reach the
+   * target page. Bare flags (`?kiosk`) keep their bare form — some
+   * dashboard plugins distinguish `?kiosk` from `?kiosk=`.
+   */
+  #buildPagePath(url: URL): string {
+    const forwarded = [...url.searchParams]
+      .filter(([key]) => !SYSTEM_PARAMS.has(key))
+      .map(([key, value]) =>
+        value === ''
+          ? encodeURIComponent(key)
+          : `${encodeURIComponent(key)}=${encodeURIComponent(value)}`,
+      )
+      .join('&')
+
+    return forwarded ? `${url.pathname}?${forwarded}` : url.pathname
   }
 
   /**

--- a/trmnl-ha/ha-trmnl/screenshot.ts
+++ b/trmnl-ha/ha-trmnl/screenshot.ts
@@ -16,7 +16,12 @@
  */
 
 import puppeteer from 'puppeteer'
-import type { Browser as PuppeteerBrowser, Page, Viewport } from 'puppeteer'
+import type {
+  Browser as PuppeteerBrowser,
+  ConsoleMessage,
+  Page,
+  Viewport,
+} from 'puppeteer'
 import {
   TIMESTAMP_OVERLAY,
   debugLogging as defaultDebugLogging,
@@ -413,36 +418,125 @@ export class Browser {
    * If targetUrl is provided, navigates directly to that URL (generic mode).
    * Otherwise, resolves pagePath against the configured base URL (HA mode).
    */
-  async navigatePage({
-    pagePath,
-    targetUrl,
-    viewport,
-    extraWait,
-    zoom = 1,
-    lang,
-    theme,
-    dark,
-  }: NavigateParams): Promise<NavigateResult> {
+  async navigatePage(params: NavigateParams): Promise<NavigateResult> {
     if (this.#busy) throw new Error('Browser is busy')
 
     const start = Date.now()
     this.#busy = true
     try {
-      // Fresh page per request: close existing page to eliminate accumulated
-      // stale state (WebSocket connections, cached renders, component state)
-      await this.#closePage()
+      // home-assistant-js-websocket's subscribeMessage() has a microtask race
+      // between handler registration and incoming WS frames. When the server's
+      // response arrives faster than the registration microtask completes
+      // (notably on cold cache where RTT is ~15ms vs ~38ms warm), HA logs
+      // "Received event for unknown subscription N. Unsubscribing." and drops
+      // the forecast/render-template data. The card never re-subscribes, so
+      // forecast renders empty.
+      //
+      // Retry strategy on detection:
+      //   - Attempt 1 is always a full fresh-page navigation (the per-request
+      //     reset that issue #34 mandates).
+      //   - Attempts 2..N reuse the live page and re-mount the panel via an
+      //     in-app router transition (pushState to '/', then back to the
+      //     target). The WebSocket connection stays open and the JS heap
+      //     stays hot, which is what actually makes the race stop losing.
+      //     Closing and re-creating the page on each retry would throw away
+      //     the warmth we need.
+      //
+      // Cost is paid only on attempts that detect the orphan warning;
+      // dashboards built from REST/static cards (no subscribeMessage calls)
+      // never trigger the retry path.
+      const MAX_ATTEMPTS = 5
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        const orphaned = await this.#runNavigationAttempt(params, attempt === 1)
+        if (!orphaned) {
+          return { time: Date.now() - start }
+        }
+        if (attempt === MAX_ATTEMPTS) {
+          log.warn`HA WS subscription race persisted after ${MAX_ATTEMPTS} attempts; some card data may be missing from this screenshot`
+          return { time: Date.now() - start }
+        }
+        log.info`HA WS subscription race detected on attempt ${attempt}; soft-retrying via in-page router transition`
+      }
+      // Loop always returns or throws; this is unreachable.
+      return { time: Date.now() - start }
+    } finally {
+      this.#busy = false
+    }
+  }
+
+  /**
+   * Runs a single navigation attempt and reports whether the HA WS
+   * subscription race was observed during the run. Throws on hard errors
+   * (browser crash, navigation failure) so the retry loop does not mask them.
+   *
+   * @param freshPage true to discard the current page and do a full
+   *   page.goto() (the per-request reset); false to reuse the live page and
+   *   re-mount the panel via an in-app router transition (used by retries).
+   * @returns true if a "Received event for unknown subscription" console
+   *   warning fired during this attempt, false otherwise.
+   */
+  async #runNavigationAttempt(
+    {
+      pagePath,
+      targetUrl,
+      viewport,
+      extraWait,
+      zoom = 1,
+      lang,
+      theme,
+      dark,
+    }: NavigateParams,
+    freshPage: boolean,
+  ): Promise<boolean> {
+    let orphanDetected = false
+    let consoleHandler: ((msg: ConsoleMessage) => void) | undefined
+    let listeningPage: Page | undefined
+
+    try {
+      if (freshPage) {
+        // Fresh page per request: close existing page to eliminate accumulated
+        // stale state (WebSocket connections, cached renders, component state)
+        await this.#closePage()
+      }
 
       const page = await this.#getPage()
-      await page.setViewport(viewport)
+      if (freshPage) {
+        await page.setViewport(viewport)
+      }
 
-      // Always first navigation on fresh page - injects auth + full page.goto()
-      const authStorage = this.#buildAuthStorage()
-      const navigateCmd = new NavigateToPage(
-        page,
-        authStorage,
-        this.#homeAssistantUrl,
-      )
-      await navigateCmd.call(pagePath, targetUrl)
+      // Listen for the orphaned-subscription console warning that signals
+      // the HA WS subscribeMessage race. Attaching here (after #getPage)
+      // catches warnings from the entire navigation, including card-mount
+      // subscribes triggered by pushState.
+      consoleHandler = (msg) => {
+        // Puppeteer 24+ returns 'warn'; older versions returned 'warning'.
+        // Accept both (as string — 'warning' left the type union) so we
+        // don't break if puppeteer's enum shifts again.
+        const type: string = msg.type()
+        if (
+          (type === 'warn' || type === 'warning') &&
+          msg.text().includes('Received event for unknown subscription')
+        ) {
+          orphanDetected = true
+        }
+      }
+      page.on('console', consoleHandler)
+      listeningPage = page
+
+      if (freshPage) {
+        // First attempt: full fresh navigation — injects auth, full page.goto()
+        const authStorage = this.#buildAuthStorage()
+        const navigateCmd = new NavigateToPage(
+          page,
+          authStorage,
+          this.#homeAssistantUrl,
+        )
+        await navigateCmd.call(pagePath, targetUrl)
+      } else {
+        // Warm retry: re-mount the panel via SPA pushState on the live page.
+        // WS connection, JS heap, and auth all carry over from attempt 1.
+        await this.#softReroute(page, pagePath, targetUrl)
+      }
 
       // Check if we landed on HA login/auth page (indicates invalid token)
       const currentUrl = page.url()
@@ -513,7 +607,7 @@ export class Browser {
         await paintCmd.call()
       }
 
-      return { time: Date.now() - start }
+      return orphanDetected
     } catch (err) {
       this.#pageErrorDetected = false
 
@@ -535,8 +629,52 @@ export class Browser {
 
       throw err
     } finally {
-      this.#busy = false
+      // Detach the orphan listener so listeners don't accumulate across
+      // retries / subsequent screenshots. Page may be closed already; ignore.
+      if (consoleHandler && listeningPage) {
+        try {
+          listeningPage.off('console', consoleHandler)
+        } catch (_err) {
+          /* page closed */
+        }
+      }
     }
+  }
+
+  /**
+   * Re-mounts the panel on the live page by routing to '/' and then back to
+   * the target path via pushState + popstate. Used by retries instead of a
+   * fresh page.goto() so the existing WebSocket connection and JS heap are
+   * preserved — those are the actual carriers of "warmth" that win the
+   * subscribeMessage race on slow hardware.
+   */
+  async #softReroute(
+    page: Page,
+    pagePath: string,
+    targetUrl?: string,
+  ): Promise<void> {
+    const pageUrl =
+      targetUrl || new URL(pagePath, this.#homeAssistantUrl).toString()
+    const u = new URL(pageUrl)
+    const targetPath = u.pathname + u.search
+
+    // Unmount the current panel by routing to '/'
+    await page.evaluate(() => {
+      history.pushState(null, '', '/')
+      window.dispatchEvent(new PopStateEvent('popstate'))
+    })
+
+    // Brief settle so HA's partial-panel-resolver tears down the panel
+    // before we route back. Without this, the back-transition can merge
+    // with the unmount and skip a full remount cycle.
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    // Route back to the target path; cards re-mount and re-subscribe on
+    // top of the live connection.
+    await page.evaluate((path: string) => {
+      history.pushState(null, '', path)
+      window.dispatchEvent(new PopStateEvent('popstate'))
+    }, targetPath)
   }
 
   /**

--- a/trmnl-ha/ha-trmnl/tests/unit/api-client.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/api-client.test.ts
@@ -17,6 +17,21 @@ afterEach(() => {
 
 describe('FetchPreview', () => {
   describe('#call', () => {
+    it('joins params with & when the path carries its own query', async () => {
+      let requestedUrl = ''
+      globalThis.fetch = (async (url: unknown) => {
+        requestedUrl = String(url)
+        return new Response(new Blob(['png']), { status: 200 })
+      }) as unknown as typeof fetch
+
+      await new FetchPreview().call(
+        '/lovelace/0?kiosk',
+        new URLSearchParams({ viewport: '800x480' }),
+      )
+
+      expect(requestedUrl).toBe('./lovelace/0?kiosk&viewport=800x480')
+    })
+
     it('rejects with response body text when request fails', async () => {
       stubFetch(
         new Response(

--- a/trmnl-ha/ha-trmnl/tests/unit/byos-auth.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/byos-auth.test.ts
@@ -302,7 +302,7 @@ describe('byos-auth', () => {
       expect(auth.obtained_at).toBeGreaterThan(Date.now() - 5000)
     })
 
-    it('returns null when refresh fails', async () => {
+    it('falls back to the stored access token when refresh fails', async () => {
       const auth: ByosAuthConfig = {
         enabled: true,
         access_token: 'old',
@@ -310,11 +310,27 @@ describe('byos-auth', () => {
         obtained_at: Date.now() - 30 * 60 * 1000,
       }
 
-      mockFetch({ ok: false, status: 401 })
+      mockFetch({ ok: false, status: 400 })
 
       const result = await getValidAccessToken('https://host.com/api', auth)
 
-      expect(result).toBeNull()
+      expect(result).toBe('old')
+    })
+
+    it('does not persist tokens when refresh fails', async () => {
+      const auth: ByosAuthConfig = {
+        enabled: true,
+        access_token: 'old',
+        refresh_token: 'refresh',
+        obtained_at: Date.now() - 30 * 60 * 1000,
+      }
+      const onTokenRefresh = mock(() => {})
+
+      mockFetch({ ok: false, status: 400 })
+
+      await getValidAccessToken('https://host.com/api', auth, onTokenRefresh)
+
+      expect(onTokenRefresh).not.toHaveBeenCalled()
     })
   })
 

--- a/trmnl-ha/ha-trmnl/tests/unit/http-router.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/http-router.test.ts
@@ -8,7 +8,10 @@
  * @module tests/unit/http-router
  */
 
-import { describe, it, expect, beforeEach, mock } from 'bun:test'
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 
 // ---------------------------------------------------------------------------
 // Mock functions — passed via constructor DI (no global mock.module needed)
@@ -1151,6 +1154,64 @@ describe('HttpRouter', () => {
       expect(mockResponse.headers['content-type']).toBe(
         'application/javascript',
       )
+    })
+  })
+
+  describe('GET /output/:filename — saved captures', () => {
+    let outputDir: string
+
+    beforeEach(() => {
+      outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'trmnl-output-'))
+      router = new HttpRouter(mockFacade, null, { ...mockDeps, outputDir })
+    })
+
+    afterEach(() => {
+      fs.rmSync(outputDir, { recursive: true, force: true })
+    })
+
+    const routeTo = async (pathname: string) => {
+      await router.route(
+        mockRequest as unknown as IncomingMessage,
+        mockResponse as unknown as ServerResponse,
+        new URL(`http://localhost${pathname}`),
+      )
+    }
+
+    it('serves a saved capture with its image content type', async () => {
+      const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47])
+      fs.writeFileSync(
+        path.join(outputDir, 'Terminus_2026-07-07T07-28-07-051Z.png'),
+        bytes,
+      )
+
+      await routeTo('/output/Terminus_2026-07-07T07-28-07-051Z.png')
+
+      expect(mockResponse.statusCode).toBe(200)
+      expect(mockResponse.headers['content-type']).toBe('image/png')
+      expect(Buffer.from(mockResponse.body)).toEqual(bytes)
+    })
+
+    it('serves bmp captures with image/bmp', async () => {
+      fs.writeFileSync(path.join(outputDir, 'Screen_1.bmp'), Buffer.from([1]))
+
+      await routeTo('/output/Screen_1.bmp')
+
+      expect(mockResponse.headers['content-type']).toBe('image/bmp')
+    })
+
+    it('returns 404 for a missing file', async () => {
+      await routeTo('/output/nope.png')
+
+      expect(mockResponse.statusCode).toBe(404)
+    })
+
+    it('rejects path traversal via encoded separators', async () => {
+      fs.writeFileSync(path.join(os.tmpdir(), 'trmnl-secret.txt'), 'secret')
+
+      await routeTo('/output/%2e%2e%2ftrmnl-secret.txt')
+
+      expect(mockResponse.statusCode).toBe(404)
+      expect(mockResponse.body).not.toContain('secret')
     })
   })
 })

--- a/trmnl-ha/ha-trmnl/tests/unit/schedule-executor.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/schedule-executor.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for Schedule Executor — BYOS URI delivery.
+ *
+ * Covers the URI sent to BYOS servers in URI delivery mode: it must point
+ * at the capture saved by the same run (served at /output/) so the BYOS
+ * fetch does not trigger a second full dashboard render (#74).
+ *
+ * Uses a temp output dir and a globalThis.fetch override (restored in
+ * afterAll) to capture the webhook payload without a network.
+ *
+ * @see lib/scheduler/schedule-executor.ts
+ * @module tests/unit/schedule-executor
+ */
+
+import { describe, it, expect, beforeEach, afterAll, mock } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { ScheduleExecutor } from '../../lib/scheduler/schedule-executor.js'
+import type { Schedule } from '../../types/domain.js'
+
+const realFetch = globalThis.fetch
+
+afterAll(() => {
+  globalThis.fetch = realFetch
+})
+
+/** Captures webhook requests and replies 200 */
+function captureFetch(requests: { url: string; body: string }[]) {
+  globalThis.fetch = mock(async (url: unknown, init?: RequestInit) => {
+    // Payloads are JSON strings; anything else would be a test setup bug
+    requests.push({ url: String(url), body: init?.body as string })
+    return new Response('{}', { status: 200 })
+  }) as unknown as typeof fetch
+}
+
+function createByosSchedule(overrides: Partial<Schedule> = {}): Schedule {
+  return {
+    id: 'byos-1',
+    name: 'Terminus',
+    enabled: true,
+    cron: '* * * * *',
+    dashboard_path: '/lovelace/0',
+    viewport: { width: 800, height: 480 },
+    format: 'png',
+    webhook_url: 'https://byos.example.com/api/screens',
+    webhook_format: {
+      format: 'byos-hanami',
+      byosConfig: {
+        model_id: '1',
+        name: 'trmnl_screen',
+        label: 'TRMNL Screen',
+        addon_base_url: 'http://192.168.1.10:10000/',
+        delivery_mode: 'uri',
+        auth: {
+          enabled: true,
+          access_token: 'token',
+          refresh_token: 'refresh',
+          obtained_at: Date.now(),
+        },
+      },
+    },
+    ...overrides,
+  } as Schedule
+}
+
+describe('ScheduleExecutor — BYOS URI delivery', () => {
+  let outputDir: string
+  let executor: ScheduleExecutor
+  let requests: { url: string; body: string }[]
+
+  beforeEach(() => {
+    outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'trmnl-executor-'))
+    executor = new ScheduleExecutor(
+      async () => Buffer.from('fake-png'),
+      outputDir,
+    )
+    requests = []
+    captureFetch(requests)
+  })
+
+  it('sends a URI pointing at the saved capture, not a render endpoint', async () => {
+    const result = await executor.call(createByosSchedule())
+
+    const payload = JSON.parse(requests[0]!.body) as {
+      screen: { uri: string }
+    }
+    const savedFilename = path.basename(result.savedPath)
+
+    expect(payload.screen.uri).toBe(
+      `http://192.168.1.10:10000/output/${savedFilename}`,
+    )
+  })
+
+  it('saves the capture the URI points at', async () => {
+    const result = await executor.call(createByosSchedule())
+
+    expect(fs.readFileSync(result.savedPath, 'utf-8')).toBe('fake-png')
+  })
+
+  it('falls back to embedded data when delivery_mode is data', async () => {
+    const schedule = createByosSchedule()
+    schedule.webhook_format!.byosConfig!.delivery_mode = 'data'
+
+    await executor.call(schedule)
+
+    const payload = JSON.parse(requests[0]!.body) as {
+      screen: { uri?: string; data?: string }
+    }
+
+    expect(payload.screen.uri).toBeUndefined()
+    expect(payload.screen.data).toBeDefined()
+  })
+})

--- a/trmnl-ha/ha-trmnl/tests/unit/screenshot-clip.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/screenshot-clip.test.ts
@@ -16,7 +16,7 @@
  * @module tests/unit/screenshot-clip
  */
 
-import { mock, describe, it, expect, beforeEach } from 'bun:test'
+import { mock, describe, it, expect, beforeEach, afterAll } from 'bun:test'
 import type { BrowserDeps } from '../../screenshot.js'
 
 // Safety: const.ts needs these env vars at module load time (no options-dev.json in CI)
@@ -34,6 +34,7 @@ interface MockPage {
   setViewport: MockFn
   close: MockFn
   on: MockFn
+  off: MockFn
   url: () => string
   waitForNetworkIdle: MockFn
   // Methods required by real NavigateToPage
@@ -43,11 +44,17 @@ interface MockPage {
   // Methods required by real wait commands and page setup strategies
   evaluate: MockFn
   waitForFunction: MockFn
+  /** Test helper: invoke all registered 'console' handlers. */
+  fireConsole: (text: string, type?: string) => void
 }
 
 let currentMockPage: MockPage
 
 function createMockPage(): MockPage {
+  // Map from event name to list of handlers. Tests can fire 'console' events
+  // via fireConsole() to exercise the orphan-detection retry path.
+  const handlers = new Map<string, ((arg: unknown) => void)[]>()
+
   const page: MockPage = {
     screenshot: mock(
       async (_opts?: unknown) =>
@@ -58,7 +65,20 @@ function createMockPage(): MockPage {
     url: () => 'http://localhost:8123/lovelace',
     waitForNetworkIdle: mock(async () => {}),
     // on() must return the page for method chaining in #setupPageLogging
-    on: mock(() => page),
+    on: mock((event: string, handler: (arg: unknown) => void) => {
+      const arr = handlers.get(event) ?? []
+      arr.push(handler)
+      handlers.set(event, arr)
+      return page
+    }),
+    off: mock((event: string, handler: (arg: unknown) => void) => {
+      const arr = handlers.get(event)
+      if (arr) {
+        const idx = arr.indexOf(handler)
+        if (idx >= 0) arr.splice(idx, 1)
+      }
+      return page
+    }),
     // NavigateToPage: inject auth → navigate → cleanup
     evaluateOnNewDocument: mock(async () => ({ identifier: 'mock-id' })),
     goto: mock(async () => ({ ok: () => true, status: () => 200 })),
@@ -66,6 +86,11 @@ function createMockPage(): MockPage {
     // Wait commands + page setup strategies
     evaluate: mock(async () => 0),
     waitForFunction: mock(async () => {}),
+    fireConsole: (text: string, type: string = 'warn') => {
+      const msg = { type: () => type, text: () => text }
+      const arr = handlers.get('console') ?? []
+      for (const h of arr) h(msg)
+    },
   }
   currentMockPage = page
   return page
@@ -274,6 +299,198 @@ describe('Browser', () => {
       })
 
       expect(typeof result.time).toBe('number')
+    })
+
+    // ------------------------------------------------------------------------
+    // Retry on HA WS subscribeMessage race
+    //
+    // home-assistant-js-websocket has a microtask race between subscribe
+    // handler registration and incoming WS frames. When triggered, HA logs
+    // "Received event for unknown subscription N" and drops forecast data.
+    // The orphan-detector listens for these warnings and retries by re-mounting
+    // the panel via in-page SPA pushState on the same live page (warm WS
+    // connection + warm JS heap is what wins the race on slow hardware).
+    // Attempt 1 is always a fresh page.goto(); attempts 2..N reuse the page.
+    // ------------------------------------------------------------------------
+
+    describe('retry on WS subscription race', () => {
+      // These tests override mockBrowserInstance.newPage.mockImplementation
+      // to inject console-warning triggers. Restore the default after the
+      // block so #screenshotPage tests below get plain pages.
+      afterAll(() => {
+        mockBrowserInstance.newPage.mockClear()
+        mockBrowserInstance.newPage.mockImplementation(async () =>
+          createMockPage(),
+        )
+      })
+
+      // Wrap a fresh page's goto() so it fires a chosen console warning AFTER
+      // the navigation handler has been attached. Used to trigger the orphan
+      // on attempt 1 (the only attempt that calls goto).
+      function makePageWithGotoTrigger(
+        text: string,
+        type: string = 'warn',
+      ): MockPage {
+        const page = createMockPage()
+        const origGoto = page.goto
+        page.goto = mock(async (url: string) => {
+          const result = await origGoto(url)
+          page.fireConsole(text, type)
+          return result
+        }) as MockFn
+        return page
+      }
+
+      // Wrap both goto() and evaluate() so the orphan warning fires on
+      // attempt 1 (via goto) AND every soft-retry (via softReroute's
+      // pushState evaluate calls). Used to exercise the MAX_ATTEMPTS cap.
+      function makePagePersistentlyOrphaning(
+        text: string,
+        type: string = 'warn',
+      ): MockPage {
+        const page = makePageWithGotoTrigger(text, type)
+        const origEvaluate = page.evaluate
+        page.evaluate = mock(
+          async (fn: (...args: unknown[]) => unknown, ...args: unknown[]) => {
+            const result = await origEvaluate(fn, ...args)
+            page.fireConsole(text, type)
+            return result
+          },
+        ) as MockFn
+        return page
+      }
+
+      it('soft-retries on the same page when an orphan warning fires', async () => {
+        const browser = new Browser(BASE_URL, TOKEN, mockDeps)
+        mockBrowserInstance.newPage.mockClear()
+
+        let pageCreatedCount = 0
+        mockBrowserInstance.newPage.mockImplementation(async () => {
+          pageCreatedCount++
+          // First (and only) page created: orphans on goto, succeeds on
+          // soft-retry (softReroute uses evaluate, not goto, so the trigger
+          // doesn't re-fire).
+          return makePageWithGotoTrigger(
+            'Received event for unknown subscription 42. Unsubscribing.',
+          )
+        })
+
+        const result = await browser.navigatePage({
+          pagePath: '/lovelace/0',
+          viewport: DEFAULT_VIEWPORT,
+        })
+
+        // Soft retry reuses the same page — only one newPage() call total.
+        expect(pageCreatedCount).toBe(1)
+        // goto called exactly once (attempt 1); retry used pushState evaluate.
+        expect(currentMockPage.goto).toHaveBeenCalledTimes(1)
+        expect(typeof result.time).toBe('number')
+      })
+
+      it('does NOT retry when no orphan warning fires', async () => {
+        const browser = new Browser(BASE_URL, TOKEN, mockDeps)
+        mockBrowserInstance.newPage.mockClear()
+
+        let pageCreatedCount = 0
+        mockBrowserInstance.newPage.mockImplementation(async () => {
+          pageCreatedCount++
+          return createMockPage()
+        })
+
+        await browser.navigatePage({
+          pagePath: '/lovelace/0',
+          viewport: DEFAULT_VIEWPORT,
+        })
+
+        expect(pageCreatedCount).toBe(1)
+      })
+
+      it('caps retries at MAX_ATTEMPTS (no infinite loop on persistent race)', async () => {
+        const browser = new Browser(BASE_URL, TOKEN, mockDeps)
+        mockBrowserInstance.newPage.mockClear()
+
+        // Every attempt orphans (goto on attempt 1, evaluate on each retry).
+        // Verify we still return after the cap and never create extra pages.
+        // Cap matches the MAX_ATTEMPTS constant in screenshot.ts (currently 5).
+        let pageCreatedCount = 0
+        mockBrowserInstance.newPage.mockImplementation(async () => {
+          pageCreatedCount++
+          return makePagePersistentlyOrphaning(
+            'Received event for unknown subscription 1. Unsubscribing.',
+          )
+        })
+
+        const result = await browser.navigatePage({
+          pagePath: '/lovelace/0',
+          viewport: DEFAULT_VIEWPORT,
+        })
+
+        // Still only one page across all soft retries.
+        expect(pageCreatedCount).toBe(1)
+        // goto called exactly once (only attempt 1 does a hard navigation).
+        expect(currentMockPage.goto).toHaveBeenCalledTimes(1)
+        expect(typeof result.time).toBe('number')
+      })
+
+      it('ignores non-orphan console warnings', async () => {
+        const browser = new Browser(BASE_URL, TOKEN, mockDeps)
+        mockBrowserInstance.newPage.mockClear()
+
+        let pageCreatedCount = 0
+        mockBrowserInstance.newPage.mockImplementation(async () => {
+          pageCreatedCount++
+          return makePageWithGotoTrigger('Some unrelated browser warning')
+        })
+
+        await browser.navigatePage({
+          pagePath: '/lovelace/0',
+          viewport: DEFAULT_VIEWPORT,
+        })
+
+        // No retry — only 1 page.
+        expect(pageCreatedCount).toBe(1)
+      })
+
+      it('ignores orphan-like warnings of non-warning type', async () => {
+        // Detector only matches type() === 'warn' | 'warning'. An 'info' or
+        // 'log' message with similar text shouldn't trigger a retry.
+        const browser = new Browser(BASE_URL, TOKEN, mockDeps)
+        mockBrowserInstance.newPage.mockClear()
+
+        let pageCreatedCount = 0
+        mockBrowserInstance.newPage.mockImplementation(async () => {
+          pageCreatedCount++
+          return makePageWithGotoTrigger(
+            'Received event for unknown subscription 7. Unsubscribing.',
+            'info',
+          )
+        })
+
+        await browser.navigatePage({
+          pagePath: '/lovelace/0',
+          viewport: DEFAULT_VIEWPORT,
+        })
+
+        expect(pageCreatedCount).toBe(1)
+      })
+
+      it('keeps #busy=false after a retried navigation completes', async () => {
+        const browser = new Browser(BASE_URL, TOKEN, mockDeps)
+        mockBrowserInstance.newPage.mockClear()
+
+        mockBrowserInstance.newPage.mockImplementation(async () =>
+          makePageWithGotoTrigger(
+            'Received event for unknown subscription 99. Unsubscribing.',
+          ),
+        )
+
+        await browser.navigatePage({
+          pagePath: '/lovelace/0',
+          viewport: DEFAULT_VIEWPORT,
+        })
+
+        expect(browser.busy).toBe(false)
+      })
     })
   })
 

--- a/trmnl-ha/ha-trmnl/tests/unit/screenshot-params-parser.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/screenshot-params-parser.test.ts
@@ -107,6 +107,44 @@ describe('ScreenshotParamsParser', () => {
   // Processing Parameters - Optional screenshot processing params
   // ==========================================================================
 
+  describe('Page query forwarding', () => {
+    it('forwards unknown params to pagePath (e.g. ?kiosk for Kiosk Mode)', () => {
+      const url = new URL('http://localhost/lovelace/0?kiosk&viewport=800x480')
+
+      const result = parser.call(url)
+
+      expect(result?.pagePath).toBe('/lovelace/0?kiosk')
+    })
+
+    it('forwards unknown params with values', () => {
+      const url = new URL(
+        'http://localhost/lovelace/0?viewport=800x480&sidebar=hidden',
+      )
+
+      const result = parser.call(url)
+
+      expect(result?.pagePath).toBe('/lovelace/0?sidebar=hidden')
+    })
+
+    it('does not forward system params', () => {
+      const url = new URL(
+        'http://localhost/lovelace/0?viewport=800x480&format=bmp&dithering&dither_method=ordered&wait=2000',
+      )
+
+      const result = parser.call(url)
+
+      expect(result?.pagePath).toBe('/lovelace/0')
+    })
+
+    it('leaves pagePath untouched without unknown params', () => {
+      const url = createUrl('/lovelace/0', { viewport: '800x480' })
+
+      const result = parser.call(url)
+
+      expect(result?.pagePath).toBe('/lovelace/0')
+    })
+  })
+
   describe('Processing Parameters', () => {
     it('includes pagePath from URL pathname', () => {
       const url = createUrl('/lovelace/dashboard', { viewport: '800x600' })
@@ -657,7 +695,6 @@ describe('ScreenshotParamsParser', () => {
         palette: 'gray-16',
         black_level: '10',
         white_level: '90',
-        normalize: true,
       })
 
       const result = parser.call(url)

--- a/trmnl-ha/ha-trmnl/tests/unit/timestamp-format.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/timestamp-format.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Tests for the capture-time overlay format (issue #68).
+ *
+ * Kept separate from dithering.test.ts because formatTimestamp is pure
+ * string formatting — no ImageMagick required.
+ *
+ * @see lib/dithering.ts
+ * @module tests/unit/timestamp-format
+ */
+
+import { describe, it, expect } from 'bun:test'
+import { formatTimestamp } from '../../lib/dithering.js'
+
+describe('formatTimestamp', () => {
+  const afternoon = new Date(2026, 6, 16, 14, 30)
+  const morning = new Date(2026, 6, 16, 9, 5)
+
+  it('formats 24-hour time by default', () => {
+    expect(formatTimestamp(afternoon, false)).toBe('2026-07-16 14:30')
+  })
+
+  it('formats 12-hour time with AM/PM when enabled', () => {
+    expect(formatTimestamp(afternoon, true)).toBe('2026-07-16 2:30 PM')
+  })
+
+  it('keeps minutes zero-padded in 12-hour mode', () => {
+    expect(formatTimestamp(morning, true)).toBe('2026-07-16 9:05 AM')
+  })
+
+  it('keeps hours zero-padded in 24-hour mode', () => {
+    expect(formatTimestamp(morning, false)).toBe('2026-07-16 09:05')
+  })
+})

--- a/trmnl-ha/ha-trmnl/tests/unit/webhook-delivery.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/webhook-delivery.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Tests for webhook delivery connection-error reporting (issue #71).
+ *
+ * Uses a globalThis.fetch override (restored in afterAll) — no network.
+ *
+ * @see lib/scheduler/webhook-delivery.ts
+ * @module tests/unit/webhook-delivery
+ */
+
+import { describe, it, expect, afterAll, mock } from 'bun:test'
+import { uploadToWebhook } from '../../lib/scheduler/webhook-delivery.js'
+
+const realFetch = globalThis.fetch
+
+afterAll(() => {
+  globalThis.fetch = realFetch
+})
+
+describe('uploadToWebhook — connection errors', () => {
+  it('names the unreachable host and suggests the DNS fix', async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error('Unable to connect. Is the computer able to access the url?')
+    }) as unknown as typeof fetch
+
+    expect(
+      uploadToWebhook({
+        webhookUrl: 'http://larapaper.home.arpa/api/plugins/abc/webhook',
+        imageBuffer: Buffer.from('png'),
+        format: 'png',
+      }),
+    ).rejects.toThrow(
+      /Could not reach larapaper\.home\.arpa:.*may not resolve inside the add-on container/,
+    )
+  })
+
+  it('passes HTTP errors through untouched', async () => {
+    globalThis.fetch = mock(
+      async () => new Response('nope', { status: 500 }),
+    ) as unknown as typeof fetch
+
+    expect(
+      uploadToWebhook({
+        webhookUrl: 'http://byos.local/api/screens',
+        imageBuffer: Buffer.from('png'),
+        format: 'png',
+      }),
+    ).rejects.toThrow(/HTTP 500/)
+  })
+})


### PR DESCRIPTION
- Run the container under tini so orphaned Chromium/crashpad processes are reaped (#72)
- Fall back to the stored BYOS access token when a refresh is rejected, instead of discarding the token pair and pushing unauthenticated (#75)
- Point BYOS URI delivery at the capture saved by the same run, served from a new /output/ route, instead of re-rendering the dashboard when the BYOS server fetches the URI (#74)
- Forward unknown query params like ?kiosk to the HA page URL and join preview params with & when the path already carries a query (#44)
- Soft-retry navigation when the HA websocket subscription race drops card data, re-mounting the panel on the live page — extracted as the layout-safe half of #55, co-authored with @michael-fritzsch
- Add a timestamp_12h option to render the capture-time overlay in 12-hour format (#68)
- Name the unreachable host in webhook connect errors and hint at the container-DNS fix (#71)
- Spell out the over-50KB warning inline in the preview instead of a hover tooltip (#70)

Verified locally: full unit + integration suites, a live end-to-end run (BYOS URI push delivers the byte-identical saved capture with no second render, ?kiosk reaches the HA URL, traversal on /output is rejected), and a container build where an orphan storm leaves zero zombies under tini.

Closes #44, closes #68, closes #70, closes #71, closes #72, closes #74, closes #75