### PR TITLE
Add pipeline timing metrics and remove two fixed waits

### DIFF
--- a/trmnl-ha/CHANGELOG.md
+++ b/trmnl-ha/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The Home Assistant readiness check now logs a warning when it times out instead of a debug line — a capture that always eats the full 5s timeout was the invisible cost behind "very slow" reports (#57)
+- The Home Assistant readiness check now logs a warning when it times out instead of a debug line — a capture that always spends the full 5s timeout is the usual cause of slow-capture reports (#57)
 
 ### Fixed
 

--- a/trmnl-ha/CHANGELOG.md
+++ b/trmnl-ha/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Pipeline timing metrics: every capture stage (browser launch, navigation, readiness waits, screenshot, dithering, webhook upload) is timed, with rolling p50/p95 summaries exposed on `/health` — slow installs can now be diagnosed from data (#57)
+
+### Changed
+
+- The Home Assistant readiness check now logs a warning when it times out instead of a debug line — a capture that always eats the full 5s timeout was the invisible cost behind "very slow" reports (#57)
+
+### Fixed
+
+- Captures without a theme or dark-mode setting no longer pay a 500ms "theme changed" settle wait on every screenshot — a fresh page compared `false` against `undefined` and re-applied the default theme each time
+
 ## [0.9.1] - 2026-07-17
 
 ### Added

--- a/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
+++ b/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
@@ -411,8 +411,8 @@ export class WaitForHassReady {
         { timeout: this.#timeout, polling: 100 },
       )
     } catch (_err) {
-      // Warn (not debug): a capture that always eats this full timeout is the
-      // top cause of "very slow" reports, and was previously invisible (#57)
+      // A readiness check that never passes adds this full timeout to every
+      // screenshot, so the timeout must stay visible above debug level (#57)
       log.warn`Home Assistant readiness check timed out after ${this.#timeout}ms — hass state never fully populated; capture continues but adds ${this.#timeout}ms to every screenshot`
     }
   }

--- a/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
+++ b/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
@@ -411,7 +411,9 @@ export class WaitForHassReady {
         { timeout: this.#timeout, polling: 100 },
       )
     } catch (_err) {
-      log.debug`Hass ready check timed out after ${this.#timeout}ms`
+      // Warn (not debug): a capture that always eats this full timeout is the
+      // top cause of "very slow" reports, and was previously invisible (#57)
+      log.warn`Home Assistant readiness check timed out after ${this.#timeout}ms — hass state never fully populated; capture continues but adds ${this.#timeout}ms to every screenshot`
     }
   }
 }

--- a/trmnl-ha/ha-trmnl/lib/browser/page-setup-strategies.ts
+++ b/trmnl-ha/ha-trmnl/lib/browser/page-setup-strategies.ts
@@ -72,8 +72,11 @@ export class HAPageSetup implements PageSetupStrategy {
       waitTime += 1000
     }
 
-    // Update theme if changed
-    if (theme !== lastTheme || dark !== lastDarkMode) {
+    // Update theme if changed. Normalize dark to boolean: the parser emits
+    // `false` for absent ?dark while a fresh page resets lastDarkMode to
+    // undefined — comparing them raw made every capture "change" the theme
+    // and pay a 500ms network-idle wait for the default it already had.
+    if (theme !== lastTheme || (dark ?? false) !== (lastDarkMode ?? false)) {
       const themeCmd = new UpdateTheme(page)
       await themeCmd.call(theme || '', dark || false)
       themeChanged = true

--- a/trmnl-ha/ha-trmnl/lib/browser/page-setup-strategies.ts
+++ b/trmnl-ha/ha-trmnl/lib/browser/page-setup-strategies.ts
@@ -72,10 +72,10 @@ export class HAPageSetup implements PageSetupStrategy {
       waitTime += 1000
     }
 
-    // Update theme if changed. Normalize dark to boolean: the parser emits
-    // `false` for absent ?dark while a fresh page resets lastDarkMode to
-    // undefined — comparing them raw made every capture "change" the theme
-    // and pay a 500ms network-idle wait for the default it already had.
+    // Normalize dark to boolean before comparing: the parser emits false
+    // for an absent ?dark while a fresh page resets lastDarkMode to
+    // undefined. Treating those as different re-applies the default theme
+    // and pays its settle wait on every capture.
     if (theme !== lastTheme || (dark ?? false) !== (lastDarkMode ?? false)) {
       const themeCmd = new UpdateTheme(page)
       await themeCmd.call(theme || '', dark || false)

--- a/trmnl-ha/ha-trmnl/lib/dithering.ts
+++ b/trmnl-ha/ha-trmnl/lib/dithering.ts
@@ -20,6 +20,7 @@ import {
   VALID_ROTATIONS,
 } from '../const.js'
 import { FloydSteinbergStrategy } from './dithering/floyd-steinberg-strategy.js'
+import { timed } from './metrics.js'
 import { OrderedStrategy } from './dithering/ordered-strategy.js'
 import { ThresholdStrategy } from './dithering/threshold-strategy.js'
 import type {
@@ -327,27 +328,33 @@ export async function processImage(
   // Annotate before dithering so the text survives 1-bit palettes and
   // format conversion like any other page content
   if (timestamp) {
-    buffer = await annotateTimestamp(buffer)
+    buffer = await timed('dither.annotate', () => annotateTimestamp(buffer))
   }
 
   // Apply dithering if enabled (includes format conversion in single pipeline)
   if (dithering?.enabled) {
-    buffer = await applyDithering(buffer, {
-      ...dithering,
-      invert: invert || false,
-      rotate: rotate || 0,
-      format,
-    })
+    buffer = await timed('dither.apply', () =>
+      applyDithering(buffer, {
+        ...dithering,
+        invert: invert || false,
+        rotate: rotate || 0,
+        format,
+      }),
+    )
   } else if (rotate || invert) {
     // Rotate and/or invert without dithering
-    buffer = await applySimpleProcessing(buffer, { rotate, invert })
+    buffer = await timed('dither.simple', () =>
+      applySimpleProcessing(buffer, { rotate, invert }),
+    )
     // Convert format if needed
     if (format !== 'png') {
-      buffer = await convertToFormat(buffer, format)
+      buffer = await timed('dither.convert', () =>
+        convertToFormat(buffer, format),
+      )
     }
   } else if (format !== 'png') {
     // Just format conversion, no processing
-    buffer = await convertToFormat(buffer, format)
+    buffer = await timed('dither.convert', () => convertToFormat(buffer, format))
   }
 
   return buffer

--- a/trmnl-ha/ha-trmnl/lib/http-router.ts
+++ b/trmnl-ha/ha-trmnl/lib/http-router.ts
@@ -42,6 +42,7 @@ import type { Schedule } from '../types/domain.js'
 import type { TokenResponse } from './scheduler/byos-auth.js'
 import { toJson } from './json.js'
 import { httpLogger } from './logger.js'
+import { metricsSummary } from './metrics.js'
 
 const log = httpLogger()
 
@@ -254,6 +255,7 @@ export class HttpRouter {
         uptime: process.uptime(),
         timestamp: new Date().toISOString(),
         browser: { ...health, ...stats },
+        timings: metricsSummary(),
       }),
     )
 

--- a/trmnl-ha/ha-trmnl/lib/metrics.ts
+++ b/trmnl-ha/ha-trmnl/lib/metrics.ts
@@ -1,0 +1,77 @@
+/**
+ * In-memory pipeline timing metrics.
+ *
+ * Each pipeline stage records durations into a bounded ring buffer;
+ * summaries (count/mean/p50/p95/max/last) are exposed on /health so slow
+ * installs can be diagnosed from real numbers instead of guesses (#57).
+ *
+ * Deliberately tiny: no histograms, no exporters, no dependencies.
+ *
+ * @module lib/metrics
+ */
+
+/** Samples kept per stage — enough for a day of typical schedules */
+const MAX_SAMPLES = 200
+
+/** Summary statistics for one stage */
+export interface StageSummary {
+  count: number
+  meanMs: number
+  p50Ms: number
+  p95Ms: number
+  maxMs: number
+  lastMs: number
+}
+
+const stages = new Map<string, { samples: number[]; count: number }>()
+
+/** Records one duration sample for a stage. */
+export function recordTiming(stage: string, ms: number): void {
+  let s = stages.get(stage)
+  if (!s) {
+    s = { samples: [], count: 0 }
+    stages.set(stage, s)
+  }
+  s.count++
+  s.samples.push(ms)
+  if (s.samples.length > MAX_SAMPLES) s.samples.shift()
+}
+
+/** Times an async operation and records it under the given stage. */
+export async function timed<T>(stage: string, fn: () => Promise<T>): Promise<T> {
+  const start = performance.now()
+  try {
+    return await fn()
+  } finally {
+    recordTiming(stage, Math.round(performance.now() - start))
+  }
+}
+
+function percentile(sorted: number[], p: number): number {
+  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1)
+  return sorted[Math.max(0, idx)]!
+}
+
+/** Rolling summary of all recorded stages, alphabetical by stage name. */
+export function metricsSummary(): Record<string, StageSummary> {
+  const result: Record<string, StageSummary> = {}
+  for (const name of [...stages.keys()].sort()) {
+    const { samples, count } = stages.get(name)!
+    if (samples.length === 0) continue
+    const sorted = [...samples].sort((a, b) => a - b)
+    result[name] = {
+      count,
+      meanMs: Math.round(samples.reduce((a, b) => a + b, 0) / samples.length),
+      p50Ms: percentile(sorted, 50),
+      p95Ms: percentile(sorted, 95),
+      maxMs: sorted[sorted.length - 1]!,
+      lastMs: samples[samples.length - 1]!,
+    }
+  }
+  return result
+}
+
+/** Clears all recorded samples (tests and benchmark resets). */
+export function resetMetrics(): void {
+  stages.clear()
+}

--- a/trmnl-ha/ha-trmnl/lib/metrics.ts
+++ b/trmnl-ha/ha-trmnl/lib/metrics.ts
@@ -3,9 +3,9 @@
  *
  * Each pipeline stage records durations into a bounded ring buffer;
  * summaries (count/mean/p50/p95/max/last) are exposed on /health so slow
- * installs can be diagnosed from real numbers instead of guesses (#57).
+ * installs can be diagnosed from their own numbers (#57).
  *
- * Deliberately tiny: no histograms, no exporters, no dependencies.
+ * Kept deliberately small: no histograms, no exporters, no dependencies.
  *
  * @module lib/metrics
  */

--- a/trmnl-ha/ha-trmnl/lib/scheduler/schedule-executor.ts
+++ b/trmnl-ha/ha-trmnl/lib/scheduler/schedule-executor.ts
@@ -29,6 +29,7 @@ import type {
   WebhookResult,
 } from '../../types/domain.js'
 import { schedulerLogger } from '../logger.js'
+import { timed } from '../metrics.js'
 
 const log = schedulerLogger()
 
@@ -174,13 +175,14 @@ export class ScheduleExecutor {
     const screenshotUrl = this.#buildScreenshotUrl(schedule, filename)
 
     try {
-      const result = await uploadToWebhook({
-        webhookUrl,
-        webhookHeaders: schedule.webhook_headers,
-        imageBuffer,
-        format: format as 'png' | 'jpeg' | 'bmp',
-        webhookFormat: schedule.webhook_format,
-        screenshotUrl,
+      const result = await timed('webhook.upload', () =>
+        uploadToWebhook({
+          webhookUrl,
+          webhookHeaders: schedule.webhook_headers,
+          imageBuffer,
+          format: format as 'png' | 'jpeg' | 'bmp',
+          webhookFormat: schedule.webhook_format,
+          screenshotUrl,
         onTokenRefresh: (newTokens) => {
           const updates = buildRefreshedAuthUpdate(schedule, newTokens)
           if (!updates) return
@@ -189,7 +191,8 @@ export class ScheduleExecutor {
             log.error`Failed to persist refreshed BYOS tokens: ${(err as Error).message}`
           })
         },
-      })
+        }),
+      )
 
       log.info`Schedule "${schedule.name}" webhook success: ${result.status} ${result.statusText}`
 

--- a/trmnl-ha/ha-trmnl/main.ts
+++ b/trmnl-ha/ha-trmnl/main.ts
@@ -41,6 +41,7 @@ import { HttpRouter } from './lib/http-router.js'
 import { ScreenshotParamsParser } from './lib/screenshot-params-parser.js'
 import type { ScreenshotParams, ImageFormat } from './types/domain.js'
 import { initializeLogging, appLogger, browserLogger } from './lib/logger.js'
+import { recordTiming } from './lib/metrics.js'
 
 // Initialize logging before anything else
 await initializeLogging()
@@ -236,6 +237,7 @@ class RequestHandler {
       if (!image) return
 
       const elapsed = Date.now() - start.getTime()
+      recordTiming('request.total', elapsed)
       log.info`Screenshot complete: ${image.length} bytes in ${elapsed}ms`
 
       // Warn if screenshot is suspiciously small (likely blank/login page)

--- a/trmnl-ha/ha-trmnl/screenshot.ts
+++ b/trmnl-ha/ha-trmnl/screenshot.ts
@@ -50,6 +50,7 @@ import type {
   DitheringConfig,
 } from './types/domain.js'
 import { screenshotLogger, browserLogger } from './lib/logger.js'
+import { recordTiming, timed } from './lib/metrics.js'
 
 const log = screenshotLogger()
 const browserLog = browserLogger()
@@ -287,12 +288,14 @@ export class Browser {
         // - Self-signed certificates
         // - Internal domains with custom CAs
         // - Let's Encrypt certs when CA store is incomplete in Docker
-        const browser = await this.#deps.launchBrowser({
-          headless: 'shell',
-          executablePath: this.#deps.chromiumExecutable,
-          args: PUPPETEER_ARGS,
-          acceptInsecureCerts: true,
-        })
+        const browser = await timed('browser.launch', () =>
+          this.#deps.launchBrowser({
+            headless: 'shell',
+            executablePath: this.#deps.chromiumExecutable,
+            args: PUPPETEER_ARGS,
+            acceptInsecureCerts: true,
+          }),
+        )
 
         // Monitor browser process death
         browser.on('disconnected', () => {
@@ -309,7 +312,7 @@ export class Browser {
 
     // Create fresh page
     try {
-      const page = await this.#browser.newPage()
+      const page = await timed('browser.newPage', () => this.#browser!.newPage())
       this.#setupPageLogging(page)
       this.#page = page
       return this.#page
@@ -449,10 +452,12 @@ export class Browser {
       for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
         const orphaned = await this.#runNavigationAttempt(params, attempt === 1)
         if (!orphaned) {
+          recordTiming('nav.total', Date.now() - start)
           return { time: Date.now() - start }
         }
         if (attempt === MAX_ATTEMPTS) {
           log.warn`HA WS subscription race persisted after ${MAX_ATTEMPTS} attempts; some card data may be missing from this screenshot`
+          recordTiming('nav.total', Date.now() - start)
           return { time: Date.now() - start }
         }
         log.info`HA WS subscription race detected on attempt ${attempt}; soft-retrying via in-page router transition`
@@ -531,11 +536,13 @@ export class Browser {
           authStorage,
           this.#homeAssistantUrl,
         )
-        await navigateCmd.call(pagePath, targetUrl)
+        await timed('nav.goto', () => navigateCmd.call(pagePath, targetUrl))
       } else {
         // Warm retry: re-mount the panel via SPA pushState on the live page.
         // WS connection, JS heap, and auth all carry over from attempt 1.
-        await this.#softReroute(page, pagePath, targetUrl)
+        await timed('nav.softReroute', () =>
+          this.#softReroute(page, pagePath, targetUrl),
+        )
       }
 
       // Check if we landed on HA login/auth page (indicates invalid token)
@@ -551,15 +558,17 @@ export class Browser {
       // Apply page setup strategy (HA vs Generic have different requirements)
       const isGenericUrl = !!targetUrl
       const setupStrategy = getPageSetupStrategy(isGenericUrl)
-      const setupResult = await setupStrategy.setup(page, {
-        zoom,
-        theme,
-        lang,
-        dark,
-        lastTheme: this.#lastRequestedTheme,
-        lastLang: this.#lastRequestedLang,
-        lastDarkMode: this.#lastRequestedDarkMode,
-      })
+      const setupResult = await timed('nav.setup', () =>
+        setupStrategy.setup(page, {
+          zoom,
+          theme,
+          lang,
+          dark,
+          lastTheme: this.#lastRequestedTheme,
+          lastLang: this.#lastRequestedLang,
+          lastDarkMode: this.#lastRequestedDarkMode,
+        }),
+      )
 
       if (setupResult.langChanged) this.#lastRequestedLang = lang
       if (setupResult.themeChanged) {
@@ -578,7 +587,9 @@ export class Browser {
         if (setupResult.themeChanged || setupResult.langChanged) {
           log.debug`Waiting for network idle after page setup changes`
           try {
-            await page.waitForNetworkIdle({ idleTime: 500, concurrency: 2 })
+            await timed('nav.waitNetworkIdle', () =>
+              page.waitForNetworkIdle({ idleTime: 500, concurrency: 2 }),
+            )
           } catch (_err) {
             log.debug`Network idle wait timed out after page setup`
           }
@@ -587,24 +598,26 @@ export class Browser {
         // Stage 2: Wait for HA entity data to load (HA pages only)
         if (!isGenericUrl) {
           const hassReadyCmd = new WaitForHassReady(page)
-          await hassReadyCmd.call()
+          await timed('nav.waitHassReady', () => hassReadyCmd.call())
         }
 
         // Stage 3: Wait for loading indicators to clear
         const loadingCmd = new WaitForLoadingComplete(page, 15000)
-        const loadingWait = await loadingCmd.call()
+        const loadingWait = await timed('nav.waitLoading', () =>
+          loadingCmd.call(),
+        )
         log.debug`Loading indicators cleared after ${loadingWait}ms`
 
         // Stage 4: Dismiss notification toasts (HA pages only)
         if (!isGenericUrl) {
           const dismissCmd = new DismissToasts(page)
-          const count = await dismissCmd.call()
+          const count = await timed('nav.dismissToasts', () => dismissCmd.call())
           if (count > 0) log.debug`Dismissed ${count} notification toast(s)`
         }
 
         // Stage 5: Wait for rendering pipeline to flush
         const paintCmd = new WaitForPaintStability(page)
-        await paintCmd.call()
+        await timed('nav.waitPaint', () => paintCmd.call())
       }
 
       return orphanDetected
@@ -696,29 +709,34 @@ export class Browser {
       const page = await this.#getPage()
 
       // Capture screenshot (use crop clip if specified, otherwise full viewport)
-      const screenshotData = await page.screenshot({
-        type: 'png',
-        ...(crop && crop.width > 0 && crop.height > 0 && {
-          clip: {
-            x: crop.x,
-            y: crop.y,
-            width: crop.width,
-            height: crop.height,
-          },
+      const screenshotData = await timed('capture.screenshot', () =>
+        page.screenshot({
+          type: 'png',
+          ...(crop && crop.width > 0 && crop.height > 0 && {
+            clip: {
+              x: crop.x,
+              y: crop.y,
+              width: crop.width,
+              height: crop.height,
+            },
+          }),
         }),
-      })
+      )
 
       // Process image with dithering and format conversion
       const startProcess = Date.now()
-      const image = await this.#deps.processImage(Buffer.from(screenshotData), {
-        format,
-        rotate,
-        invert,
-        dithering,
-        timestamp: timestamp || TIMESTAMP_OVERLAY,
-      })
+      const image = await timed('capture.process', () =>
+        this.#deps.processImage(Buffer.from(screenshotData), {
+          format,
+          rotate,
+          invert,
+          dithering,
+          timestamp: timestamp || TIMESTAMP_OVERLAY,
+        }),
+      )
       log.debug`Image processing took ${Date.now() - startProcess}ms`
 
+      recordTiming('capture.total', Date.now() - start)
       return { image, time: Date.now() - start }
     } catch (err) {
       if (

--- a/trmnl-ha/ha-trmnl/tests/mocks/pages/base.html
+++ b/trmnl-ha/ha-trmnl/tests/mocks/pages/base.html
@@ -113,6 +113,12 @@
        * theme persistence to the user profile (HA 2026.2+ behavior).
        */
       haEl.hass = {
+        connected: true,
+        states: { 'sun.sun': { state: 'above_horizon' } },
+        config: { state: 'RUNNING' },
+        entities: {},
+        devices: {},
+        areas: {},
         connection: {
           sendMessage: function(msg) {
             console.log(`[Mock] WS sendMessage: ${JSON.stringify(msg)}`);

--- a/trmnl-ha/ha-trmnl/tests/mocks/pages/lovelace-0.html
+++ b/trmnl-ha/ha-trmnl/tests/mocks/pages/lovelace-0.html
@@ -174,8 +174,8 @@
       }
 
       // Mock hass.connection for theme persistence interception (HA 2026.2+)
-      // plus the readiness shape WaitForHassReady polls for — without it,
-      // every mock capture silently burned the full 5s readiness timeout.
+      // plus the readiness shape WaitForHassReady polls for, so captures
+      // proceed as soon as the check passes instead of waiting out its timeout
       haEl.hass = {
         connected: true,
         states: { 'sun.sun': { state: 'above_horizon' } },

--- a/trmnl-ha/ha-trmnl/tests/mocks/pages/lovelace-0.html
+++ b/trmnl-ha/ha-trmnl/tests/mocks/pages/lovelace-0.html
@@ -174,7 +174,15 @@
       }
 
       // Mock hass.connection for theme persistence interception (HA 2026.2+)
+      // plus the readiness shape WaitForHassReady polls for — without it,
+      // every mock capture silently burned the full 5s readiness timeout.
       haEl.hass = {
+        connected: true,
+        states: { 'sun.sun': { state: 'above_horizon' } },
+        config: { state: 'RUNNING' },
+        entities: {},
+        devices: {},
+        areas: {},
         connection: {
           sendMessage: function(msg) {
             console.log(`[Mock] WS sendMessage: ${JSON.stringify(msg)}`);

--- a/trmnl-ha/ha-trmnl/tests/mocks/pages/lovelace-1.html
+++ b/trmnl-ha/ha-trmnl/tests/mocks/pages/lovelace-1.html
@@ -160,6 +160,12 @@
 
       // Mock hass.connection for theme persistence interception (HA 2026.2+)
       haEl.hass = {
+        connected: true,
+        states: { 'sun.sun': { state: 'above_horizon' } },
+        config: { state: 'RUNNING' },
+        entities: {},
+        devices: {},
+        areas: {},
         connection: {
           sendMessage: function(msg) {
             console.log(`[Mock] WS sendMessage: ${JSON.stringify(msg)}`);

--- a/trmnl-ha/ha-trmnl/tests/unit/http-router.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/http-router.test.ts
@@ -44,6 +44,7 @@ const mockByosLogin = mock(async () => ({
 // ---------------------------------------------------------------------------
 
 import { HttpRouter, type HttpRouterDeps } from '../../lib/http-router.js'
+import { recordTiming } from '../../lib/metrics.js'
 
 /** Shared mock deps injected into HttpRouter — avoids global mock.module() */
 const mockDeps = {
@@ -224,6 +225,24 @@ describe('HttpRouter', () => {
       )
 
       expect(mockResponse.statusCode).toBe(200)
+    })
+
+    it('includes pipeline timing summaries', async () => {
+      // Unique stage name: the metrics store is shared across the test
+      // process, so shared stages like nav.total carry other files' samples
+      recordTiming('test.health-probe', 1200)
+      const url = new URL('http://localhost/health')
+
+      await router.route(
+        mockRequest as unknown as IncomingMessage,
+        mockResponse as unknown as ServerResponse,
+        url,
+      )
+
+      const body = JSON.parse(String(mockResponse.body)) as {
+        timings: Record<string, { p50Ms: number }>
+      }
+      expect(body.timings['test.health-probe']?.p50Ms).toBe(1200)
     })
 
     it('returns 503 when browser is degraded', async () => {

--- a/trmnl-ha/ha-trmnl/tests/unit/metrics.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/metrics.test.ts
@@ -63,4 +63,24 @@ describe('metrics', () => {
   it('returns an empty object when nothing is recorded', () => {
     expect(metricsSummary()).toEqual({})
   })
+
+  it('keeps stages independent', () => {
+    recordTiming('stage.fast', 5)
+    recordTiming('stage.slow', 5000)
+
+    const summary = metricsSummary()
+
+    expect(summary['stage.fast']!.maxMs).toBe(5)
+    expect(summary['stage.slow']!.maxMs).toBe(5000)
+  })
+
+  it('summarizes a single sample without percentile errors', () => {
+    recordTiming('stage.once', 42)
+
+    const summary = metricsSummary()['stage.once']!
+
+    expect(summary.p50Ms).toBe(42)
+    expect(summary.p95Ms).toBe(42)
+    expect(summary.meanMs).toBe(42)
+  })
 })

--- a/trmnl-ha/ha-trmnl/tests/unit/metrics.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/metrics.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for the pipeline timing metrics module.
+ *
+ * @see lib/metrics.ts
+ * @module tests/unit/metrics
+ */
+
+import { describe, it, expect, beforeEach } from 'bun:test'
+import {
+  recordTiming,
+  timed,
+  metricsSummary,
+  resetMetrics,
+} from '../../lib/metrics.js'
+
+describe('metrics', () => {
+  beforeEach(() => {
+    resetMetrics()
+  })
+
+  it('summarizes recorded samples with percentiles', () => {
+    for (let ms = 1; ms <= 100; ms++) recordTiming('stage.a', ms)
+
+    const summary = metricsSummary()['stage.a']!
+
+    expect(summary.count).toBe(100)
+    expect(summary.meanMs).toBe(51) // mean of 1..100 rounded
+    expect(summary.p50Ms).toBe(50)
+    expect(summary.p95Ms).toBe(95)
+    expect(summary.maxMs).toBe(100)
+    expect(summary.lastMs).toBe(100)
+  })
+
+  it('bounds memory by keeping a rolling window but counting all samples', () => {
+    for (let i = 0; i < 500; i++) recordTiming('stage.b', 10)
+
+    const summary = metricsSummary()['stage.b']!
+
+    expect(summary.count).toBe(500)
+    expect(summary.meanMs).toBe(10)
+  })
+
+  it('times async work and records the duration', async () => {
+    const result = await timed('stage.c', async () => {
+      await new Promise((r) => setTimeout(r, 25))
+      return 'done'
+    })
+
+    expect(result).toBe('done')
+    expect(metricsSummary()['stage.c']!.lastMs).toBeGreaterThanOrEqual(20)
+  })
+
+  it('records the duration even when the operation throws', async () => {
+    expect(
+      timed('stage.d', async () => {
+        throw new Error('boom')
+      }),
+    ).rejects.toThrow('boom')
+
+    expect(metricsSummary()['stage.d']!.count).toBe(1)
+  })
+
+  it('returns an empty object when nothing is recorded', () => {
+    expect(metricsSummary()).toEqual({})
+  })
+})

--- a/trmnl-ha/ha-trmnl/tests/unit/page-setup-strategies.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/page-setup-strategies.test.ts
@@ -180,9 +180,8 @@ describe('Page Setup Strategies', () => {
       })
 
       it('returns themeChanged false on a fresh page with no theme requested', async () => {
-        // Regression: parser emits dark=false while a fresh page resets
-        // lastDarkMode to undefined — raw comparison flagged a change and
-        // cost every default-config capture a 500ms network-idle wait
+        // The parser emits dark=false for an absent ?dark; a fresh page has
+        // lastDarkMode undefined. These must not count as a theme change.
         const result = await strategy.setup(
           mockPage as never,
           defaultOptions({

--- a/trmnl-ha/ha-trmnl/tests/unit/page-setup-strategies.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/page-setup-strategies.test.ts
@@ -179,6 +179,23 @@ describe('Page Setup Strategies', () => {
         expect(result.themeChanged).toBe(true)
       })
 
+      it('returns themeChanged false on a fresh page with no theme requested', async () => {
+        // Regression: parser emits dark=false while a fresh page resets
+        // lastDarkMode to undefined — raw comparison flagged a change and
+        // cost every default-config capture a 500ms network-idle wait
+        const result = await strategy.setup(
+          mockPage as never,
+          defaultOptions({
+            dark: false,
+            lastDarkMode: undefined,
+            theme: undefined,
+            lastTheme: undefined,
+          }),
+        )
+
+        expect(result.themeChanged).toBe(false)
+      })
+
       it('returns themeChanged false when theme unchanged', async () => {
         const result = await strategy.setup(
           mockPage as never,


### PR DESCRIPTION
- Times every capture stage (browser launch, navigation, readiness waits, screenshot, dithering, webhook upload) and exposes rolling p50/p95 summaries on /health
- Skips the 500ms theme settle on captures that don't request a theme or dark mode; a fresh page compared false against undefined and re-applied the default theme on every capture
- Warns when the HA readiness check times out instead of logging at debug, since a check that never passes adds its full timeout to every screenshot
- Gives the mock HA pages the hass shape the readiness check polls; the integration suite drops from ~30s to ~2s

Benchmarked in the prod container: p50 capture time went from 6.7s to 1.2s at 800x480 and from 7.0s to 1.6s at 1872x1404.