### PR TITLE
Wait for load instead of network idle during navigation

### DIFF
--- a/trmnl-ha/CHANGELOG.md
+++ b/trmnl-ha/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Captures without a theme or dark-mode setting no longer pay a 500ms "theme changed" settle wait on every screenshot — a fresh page compared `false` against `undefined` and re-applied the default theme each time
 - A malformed webhook URL now surfaces the connection error naming the URL, instead of failing with a bare TypeError while composing that message
 
+## [Unreleased]
+
+### Changed
+
+- Navigation waits for the page load event instead of network idle, cutting ~400ms from every capture. Readiness is detected by the checks that follow (hass state, loading indicators, paint stability), which the network-idle window duplicated
+
 ## [0.9.1] - 2026-07-17
 
 ### Added

--- a/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
+++ b/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
@@ -81,8 +81,12 @@ export class NavigateToPage {
 
     let response
     try {
+      // 'load' is enough here: the wait pipeline that follows (hass
+      // readiness, loading indicators, paint stability) detects actual
+      // readiness, and a network-idle wait would add a fixed 500ms idle
+      // window on top of it.
       response = await this.#page.goto(pageUrl, {
-        waitUntil: 'networkidle2',
+        waitUntil: 'load',
         timeout: NAVIGATION_TIMEOUT,
       })
     } catch (err) {

--- a/trmnl-ha/ha-trmnl/tests/unit/navigation-commands.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/navigation-commands.test.ts
@@ -270,8 +270,21 @@ describe('NavigateToPage', () => {
         waitUntil?: string
         timeout?: number
       }
-      expect(opts.waitUntil).toBe('networkidle2')
       expect(opts.timeout).toBe(NAVIGATION_TIMEOUT)
+    })
+
+    it('waits only for the load event, not network idle', async () => {
+      const mockPage = createMockPage()
+      const nav = new NavigateToPage(
+        mockPage,
+        STUB_AUTH,
+        'http://homeassistant:8123',
+      )
+
+      await nav.call('/lovelace/0')
+
+      const opts = mockPage.calls.gotoOptions[0] as { waitUntil?: string }
+      expect(opts.waitUntil).toBe('load')
     })
   })
 


### PR DESCRIPTION
- Navigation waits for the page load event instead of networkidle2; the wait pipeline that follows (hass readiness, loading indicators, paint stability) detects actual readiness, and the network-idle window added a fixed 500ms on top of it

Validated against a real Home Assistant instance with live weather-forecast subscriptions: across 30 captures, 29 were byte-identical to the control build's outputs and forecasts were present in all 30; the one variance was a fading ripple caught mid-animation that disappears under e-ink dithering. Median capture time dropped from 1095ms to 673ms.