### PR TITLE
Fix and enable the AppArmor profile

### DIFF
--- a/trmnl-ha/apparmor.txt
+++ b/trmnl-ha/apparmor.txt
@@ -1,11 +1,14 @@
 #include <tunables/global>
 
-# NOTE: Remove 'complain' flag after testing to enforce restrictions
-# To check for issues after deploying, SSH into HA, then:
-# journalctl _TRANSPORT="audit" | grep 'apparmor="ALLOWED"' | grep trmnl-ha
-profile trmnl-ha flags=(attach_disconnected,mediate_deleted,complain) {
+# To audit denials after deploying, SSH into HA, then:
+# journalctl _TRANSPORT="audit" | grep 'apparmor="DENIED"' | grep trmnl-ha
+profile trmnl-ha flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
   #include <abstractions/nameservice>
+
+  # Container working directory and filesystem root
+  / r,
+  /app/ r,
 
   # =============================================================================
   # CAPABILITIES (minimal set for container operation)
@@ -40,11 +43,17 @@ profile trmnl-ha flags=(attach_disconnected,mediate_deleted,complain) {
   /lib64/** rm,
   /usr/lib/** rm,
 
+  # Binaries and libraries the image installs under /usr/local: the Bun
+  # runtime, the ImageMagick 7 binary, and the convert wrapper all live here
+  /usr/local/bin/** rix,
+  /usr/local/lib/** rm,
+
   # =============================================================================
   # BUN RUNTIME
   # =============================================================================
 
-  /root/.bun/** rix,
+  /root/.bun/ rw,
+  /root/.bun/** rwkix,
 
   # =============================================================================
   # APPLICATION (/app)
@@ -87,17 +96,23 @@ profile trmnl-ha flags=(attach_disconnected,mediate_deleted,complain) {
   # CHROMIUM BROWSER
   # =============================================================================
 
-  # Chromium binaries
+  # Chromium binaries and launch wrapper config. The helper executables
+  # (chrome-sandbox, chrome_crashpad_handler) need exec, so the tree is rix.
   /usr/bin/chromium rix,
   /usr/lib/chromium/ r,
-  /usr/lib/chromium/** rm,
-  /usr/lib/chromium/chromium rix,
-  /usr/lib/chromium/chrome-sandbox rix,
+  /usr/lib/chromium/** rmix,
+  /etc/chromium.d/ r,
+  /etc/chromium.d/** r,
+  /etc/chromium/ r,
+  /etc/chromium/** r,
 
-  # Chromium needs to read /proc for sandboxing
+  # Chromium needs to read /proc for sandboxing, and to tune its own
+  # processes (out-of-memory score, reference clearing)
   @{PROC}/ r,
   @{PROC}/** r,
   @{PROC}/sys/kernel/random/uuid r,
+  owner @{PROC}/*/oom_score_adj rw,
+  owner @{PROC}/*/clear_refs w,
 
   # Device access
   /dev/null rw,
@@ -117,11 +132,18 @@ profile trmnl-ha flags=(attach_disconnected,mediate_deleted,complain) {
   owner /root/.pki/ rw,
   owner /root/.pki/** rwk,
 
-  # Fonts for rendering
+  # Fonts for rendering. fontconfig enumerates the font directories, so the
+  # directory entries are read on top of their contents, and it takes file
+  # locks on its cache.
+  /usr/share/fonts/ r,
   /usr/share/fonts/** r,
+  /usr/local/share/fonts/ r,
+  /usr/local/share/fonts/** r,
+  /usr/share/fontconfig/ r,
+  /usr/share/fontconfig/** r,
   /etc/fonts/** r,
   /var/cache/fontconfig/ r,
-  /var/cache/fontconfig/** rw,
+  /var/cache/fontconfig/** rwkl,
 
   # =============================================================================
   # IMAGEMAGICK
@@ -132,8 +154,12 @@ profile trmnl-ha flags=(attach_disconnected,mediate_deleted,complain) {
   /usr/bin/mogrify rix,
   /usr/lib/*/ImageMagick*/ r,
   /usr/lib/*/ImageMagick*/** rm,
+  /usr/local/lib/ImageMagick*/ r,
+  /usr/local/lib/ImageMagick*/** rm,
   /etc/ImageMagick*/ r,
   /etc/ImageMagick*/** r,
+  /usr/local/etc/ImageMagick*/ r,
+  /usr/local/etc/ImageMagick*/** r,
   /usr/share/ImageMagick*/ r,
   /usr/share/ImageMagick*/** r,
 
@@ -169,6 +195,11 @@ profile trmnl-ha flags=(attach_disconnected,mediate_deleted,complain) {
   /etc/machine-id r,
   /etc/ld.so.cache r,
   /etc/ld.so.preload r,
+
+  # Chromium probes these on startup; it falls back cleanly when absent, but
+  # reading them keeps the audit log quiet
+  /etc/pulse/** r,
+  /usr/share/glib-2.0/** r,
 
   # =============================================================================
   # EXPLICIT DENIALS (defense in depth)

--- a/trmnl-ha/config.yaml
+++ b/trmnl-ha/config.yaml
@@ -8,7 +8,7 @@ image: ghcr.io/usetrmnl/trmnl-ha-{arch}
 # codenotary: dev@usetrmnl.com
 homeassistant_api: true
 init: false # Image ships its own init (tini) to reap orphaned Chromium children (#72)
-apparmor: false # TODO: Enable after apparmor is tested. Disabling for now to resolve "audit backlog limit exceeded" warnings
+apparmor: true
 watchdog: "http://[HOST]:10000/health"
 arch:
   - aarch64


### PR DESCRIPTION
The committed profile denied paths the current image needs, so enforcing it as-is would have stopped the add-on from starting. This adds the missing grants and switches the profile from complain mode to enforce, and sets apparmor: true.

What was missing:
- The Bun runtime and ImageMagick binaries under /usr/local/bin, and libraries under /usr/local/lib
- Chromium's helper executables (the crashpad handler needs exec, not just read)
- The fontconfig directories, so text renders
- ImageMagick config under /usr/local/etc
- The container working directory and root reads Bun makes at startup

Tested against a real Home Assistant instance with the profile loaded into the kernel in enforce mode (rootful Docker in a Lima VM, since Docker Desktop on macOS has no AppArmor). Results:
- The add-on runs with zero denials
- A full capture including Floyd-Steinberg dithering produces byte-identical output to the unconfined image
- Writing to /data is allowed but executing from it is denied, and reading /config/secrets.yaml is denied

Enforce mode also removes the audit-backlog warnings that complain mode caused (it audited every allowed operation), which is what had kept the profile disabled.

Paths added come from fixed COPY destinations in the Dockerfile, so they are the same on aarch64 and amd64; the profile was exercised on aarch64.