### PR TITLE
Node runtime fallback for CPUs Bun cannot run on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,13 +155,36 @@ jobs:
           cache-to: ${{ github.event_name == 'push' && format('type=registry,ref={0}/{1}:{2},mode=max', env.REGISTRY, env.CACHE_REPO, matrix.tag) || format('type=gha,mode=max,scope=build-{0}', matrix.tag) }}
           provenance: false
 
-      - name: Verify Bun installation in image
-        run: docker run --rm trmnl-ha:test-${{ matrix.tag }} bun --version
-
-      - name: Test image can start
+      - name: Verify both runtimes are in the image
         run: |
-          docker run -d --name test-container trmnl-ha:test-${{ matrix.tag }}
-          sleep 5
-          docker logs test-container
-          docker stop test-container
-          docker rm test-container
+          docker run --rm trmnl-ha:test-${{ matrix.tag }} bun --version
+          docker run --rm trmnl-ha:test-${{ matrix.tag }} node --version
+
+      # Boots the image and waits for /health. Runs once per runtime: the
+      # default (Bun) path and the Node fallback (RUNTIME=node), so the Node
+      # path cannot silently break. A dummy HA URL is fine — /health reports
+      # browser state and does not require HA to be reachable.
+      - name: Smoke test both runtimes
+        run: |
+          set -e
+          smoke() {
+            local name=$1 expect_log=$2
+            shift 2
+            docker run -d --name "$name" -p 10000:10000 \
+              -e HOME_ASSISTANT_URL=http://127.0.0.1:1 -e ACCESS_TOKEN=dummy \
+              "$@" trmnl-ha:test-${{ matrix.tag }} >/dev/null
+            for i in $(seq 1 45); do
+              curl -sf http://localhost:10000/health >/dev/null 2>&1 && break
+              sleep 2
+            done
+            curl -sf http://localhost:10000/health >/dev/null \
+              || { echo "::error::$name did not become healthy"; docker logs "$name"; exit 1; }
+            docker logs "$name" 2>&1 | grep -q "$expect_log" \
+              || { echo "::error::$name log missing: $expect_log"; docker logs "$name"; exit 1; }
+            curl -sf http://localhost:10000/js/app.js >/dev/null \
+              || { echo "::error::$name failed to serve transpiled frontend"; exit 1; }
+            echo "$name OK"
+            docker rm -f "$name" >/dev/null
+          }
+          smoke bun-runtime "Starting TRMNL HA"
+          smoke node-runtime "Starting under Node" -e RUNTIME=node

--- a/trmnl-ha/CHANGELOG.md
+++ b/trmnl-ha/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Node runtime fallback for CPUs that Bun's baseline build cannot run on: the image ships Node alongside Bun and the entrypoint falls back to it automatically when Bun fails to start (#24). Set the `RUNTIME` environment variable to `node` or `bun` to force a choice.
+- The AppArmor profile is fixed and enabled: it now grants the paths the current image needs and runs in enforce mode, blocking access to `/config`, `/ssl`, and execution from `/data` (#27)
+
 ## [0.9.2] - 2026-07-17
 
 ### Added

--- a/trmnl-ha/DOCS.md
+++ b/trmnl-ha/DOCS.md
@@ -111,6 +111,7 @@ Both options work — the app auto-detects which path is available. If you're al
 | `KEEP_BROWSER_OPEN` | No | Keep browser alive between requests (default: `false`) |
 | `TZ` | No | Timezone for scheduled captures (e.g., `America/New_York`) |
 | `DEBUG_LOGGING` | No | Enable verbose logging (default: `false`) |
+| `RUNTIME` | No | Force the runtime: `bun` or `node`. Default auto-detects and falls back to Node when Bun cannot start (older CPUs) |
 
 Access the Web UI at `http://localhost:10000/`
 

--- a/trmnl-ha/Dockerfile
+++ b/trmnl-ha/Dockerfile
@@ -135,6 +135,7 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
   CMD curl -f http://localhost:10000/health || exit 1
 
 # Use entrypoint for setup, wrapped in tini so PID 1 reaps orphaned
-# Chromium/crashpad children (Bun as PID 1 never wait()s them — see #72)
+# Chromium/crashpad children (Bun as PID 1 never wait()s them — see #72).
+# No CMD: the entrypoint picks the runtime (Bun, or Node on old CPUs) when
+# launched with no arguments, and runs any explicit command as-is.
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
-CMD ["bun", "run", "main.js"]

--- a/trmnl-ha/Dockerfile
+++ b/trmnl-ha/Dockerfile
@@ -99,8 +99,16 @@ RUN chmod +x /usr/local/bin/convert && \
 # NOTE: /usr/local/bin is already in PATH, no additional ENV needed
 COPY --from=builder /usr/local/bin/bun /usr/local/bin/bun
 
-# Verify Bun is available
-RUN bun --version
+# Node is the fallback runtime for CPUs too old for Bun's baseline build
+# (#24). Debian's node is too old to resolve the app's .js import specifiers,
+# so install Node 20 LTS from NodeSource.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs
+
+# Verify both runtimes are available
+RUN bun --version && node --version
 
 WORKDIR /app
 

--- a/trmnl-ha/apparmor.txt
+++ b/trmnl-ha/apparmor.txt
@@ -65,6 +65,8 @@ profile trmnl-ha flags=(attach_disconnected,mediate_deleted) {
   /app/*.ts r,
   /app/node_modules/** rm,
   /app/node_modules/.bin/** rix,
+  # esbuild ships a native binary tsx spawns on the Node fallback path (#24)
+  /app/node_modules/@esbuild/*/bin/* rix,
 
   # Logs and output directories (read/write/create)
   /app/logs/ rw,

--- a/trmnl-ha/ha-trmnl/bun.lock
+++ b/trmnl-ha/ha-trmnl/bun.lock
@@ -6,10 +6,12 @@
       "name": "ha-trmnl",
       "dependencies": {
         "@logtape/logtape": "^1.3.5",
+        "esbuild": "0.28.1",
         "gm": "^1.25.1",
         "home-assistant-js-websocket": "^9.6.0",
         "node-cron": "^4.2.1",
         "puppeteer": "^24.34.0",
+        "tsx": "^4.23.1",
         "ws": "^8.18.0",
       },
       "devDependencies": {
@@ -30,6 +32,58 @@
     "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g=="],
 
@@ -177,6 +231,8 @@
 
     "error-ex": ["error-ex@1.3.2", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g=="],
 
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
@@ -224,6 +280,8 @@
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
     "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
@@ -380,6 +438,8 @@
     "ts-api-utils": ["ts-api-utils@2.2.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-L6f5oQRAoLU1RwXz0Ab9mxsE7LtxeVB6AIR1lpkZMsOyg/JXeaxBaXa/FVCBZyNr9S9I4wkHrlZTklX+im+WMw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsx": ["tsx@4.23.1", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 

--- a/trmnl-ha/ha-trmnl/lib/http-router.ts
+++ b/trmnl-ha/ha-trmnl/lib/http-router.ts
@@ -43,6 +43,7 @@ import type { TokenResponse } from './scheduler/byos-auth.js'
 import { toJson } from './json.js'
 import { httpLogger } from './logger.js'
 import { metricsSummary } from './metrics.js'
+import { transpileTypeScript } from './transpile-ts.js'
 
 const log = httpLogger()
 
@@ -498,9 +499,7 @@ export class HttpRouter {
         const tsPath = filePath.replace(/\.js$/, '.ts')
         try {
           const tsContent = await readFile(tsPath, 'utf-8')
-          // Transpile TypeScript to JavaScript using Bun
-          const transpiler = new Bun.Transpiler({ loader: 'ts' })
-          content = transpiler.transformSync(tsContent)
+          content = await transpileTypeScript(tsContent)
           contentType = 'application/javascript'
         } catch {
           // Fall back to .js file if .ts doesn't exist

--- a/trmnl-ha/ha-trmnl/lib/transpile-ts.ts
+++ b/trmnl-ha/ha-trmnl/lib/transpile-ts.ts
@@ -1,0 +1,24 @@
+/**
+ * Transpiles a TypeScript source string to JavaScript for on-the-fly
+ * frontend serving.
+ *
+ * Uses Bun's built-in transpiler when running under Bun, and esbuild
+ * (bundled with tsx) when running under Node. The Node path is only
+ * reached on CPUs too old for Bun's baseline build; see docker-entrypoint.sh.
+ *
+ * @module lib/transpile-ts
+ */
+
+/** Bun's transpiler is present only under the Bun runtime. */
+declare const Bun:
+  | { Transpiler: new (opts: { loader: string }) => { transformSync(src: string): string } }
+  | undefined
+
+/** Transpiles TypeScript source to JavaScript. */
+export async function transpileTypeScript(source: string): Promise<string> {
+  if (typeof Bun !== 'undefined') {
+    return new Bun.Transpiler({ loader: 'ts' }).transformSync(source)
+  }
+  const { transformSync } = await import('esbuild')
+  return transformSync(source, { loader: 'ts', format: 'esm' }).code
+}

--- a/trmnl-ha/ha-trmnl/package.json
+++ b/trmnl-ha/ha-trmnl/package.json
@@ -33,10 +33,12 @@
   },
   "dependencies": {
     "@logtape/logtape": "^1.3.5",
+    "esbuild": "0.28.1",
     "gm": "^1.25.1",
     "home-assistant-js-websocket": "^9.6.0",
     "node-cron": "^4.2.1",
     "puppeteer": "^24.34.0",
+    "tsx": "^4.23.1",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/trmnl-ha/ha-trmnl/scripts/docker-entrypoint.sh
+++ b/trmnl-ha/ha-trmnl/scripts/docker-entrypoint.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+# Run an explicit command as-is (e.g. `docker run <image> bun --version`)
+# without the app setup below; only the default no-argument launch continues.
+if [ "$#" -gt 0 ]; then
+  exec "$@"
+fi
+
 echo "Starting TRMNL HA..."
 
 # Ensure data subdirectories exist for persistence.

--- a/trmnl-ha/ha-trmnl/scripts/docker-entrypoint.sh
+++ b/trmnl-ha/ha-trmnl/scripts/docker-entrypoint.sh
@@ -17,4 +17,18 @@ fi
 # Local app directories (logs stay app-local, not persisted)
 mkdir -p logs
 
-exec "$@"
+# Pick a runtime. Bun's baseline build still needs CPU instructions that
+# pre-2013 x86 chips lack and crashes on startup there (#24); fall back to
+# Node via tsx when Bun can't run. RUNTIME=node|bun forces a choice.
+# Invoke tsx via `node --import` so Node reads the loader as a module. Exec-ing
+# node_modules/.bin/tsx instead would resolve its shebang and demand execute
+# permission on tsx's script, which the AppArmor profile does not grant.
+if [ "$RUNTIME" = "node" ]; then
+  echo "Starting under Node (RUNTIME=node)"
+  exec node --import tsx main.ts
+elif [ "$RUNTIME" != "bun" ] && ! bun --version >/dev/null 2>&1; then
+  echo "Bun failed to start (unsupported CPU?); falling back to Node"
+  exec node --import tsx main.ts
+fi
+
+exec bun run main.ts


### PR DESCRIPTION
Re-targets the Node fallback work onto main (the original #81 merged into its stacked base branch instead of main).

Bun's baseline build needs CPU instructions that pre-2013 x86 chips lack, and it crashes on startup there before any app code runs (#24). This ships Node alongside Bun and falls back to it automatically.

What it does:
- The entrypoint probes bun; if it cannot start, it runs the app under Node via tsx. RUNTIME=node or RUNTIME=bun forces a choice.
- The only Bun-specific API is the on-the-fly frontend TypeScript transpiler; it now uses Bun's transpiler under Bun and esbuild under Node behind one helper.
- The AppArmor profile grants exec on esbuild's native binary for the Node path.
- CI boots the image once per runtime and fails unless each becomes healthy, logs the expected runtime, and serves the transpiled frontend.

Verified in a Lima VM with the profile enforced in the kernel: both runtimes run confined with zero denials, captures are byte-identical, auto-detection falls back when bun is broken, and /config reads and execution from /data stay denied.

Note: Node adds roughly 150MB to the image, carried by every install even though only old-CPU hosts use the fallback. Can be slimmed later by copying just the node binary instead of the full NodeSource package.