### PR TITLE
Fix blank and partly drawn screenshots

### DIFF
--- a/trmnl-ha/ha-trmnl/html/js/preview-generator.ts
+++ b/trmnl-ha/ha-trmnl/html/js/preview-generator.ts
@@ -111,19 +111,10 @@ export class PreviewGenerator {
       loadTime.textContent = `${Math.round(loadTimeMs)}ms`
     }
 
-    // Display file size with warning if over 50KB. The warning is spelled
-    // out inline — a tooltip-only hint was missed and led to devices
-    // crash-looping on oversized images (#70).
     if (fileSize) {
-      const sizeKB = (sizeBytes / 1024).toFixed(1)
-      const isOverLimit = sizeBytes > 50 * 1024
-      fileSize.textContent = isOverLimit
-        ? `${sizeKB} KB — ⚠ exceeds the TRMNL 50KB limit; the device may fail to display it. Reduce dashboard complexity, bit depth, or viewport size.`
-        : `${sizeKB} KB`
-      fileSize.className = isOverLimit ? 'text-red-500 font-bold' : 'text-muted'
-      fileSize.title = isOverLimit
-        ? 'Warning: Image exceeds TRMNL 50KB limit'
-        : 'File size'
+      fileSize.textContent = `${(sizeBytes / 1024).toFixed(1)} KB`
+      fileSize.className = 'text-muted'
+      fileSize.title = 'File size'
       fileSize.classList.remove('hidden')
     }
 

--- a/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
+++ b/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
@@ -24,6 +24,9 @@ import { navigationLogger } from '../logger.js'
 
 const log = navigationLogger()
 
+/** Set once the warning below has been given, so it is given only once. */
+let warnedAboutInternals = false
+
 /** Auth storage for localStorage injection */
 export type AuthStorage = Record<string, string>
 
@@ -187,11 +190,98 @@ export class WaitForPageLoad {
   }
 }
 
+const LOADING_SELECTORS = [
+  'ha-circular-progress',
+  'hass-loading-screen',
+  '.loading',
+  '.spinner',
+  '[loading]',
+  'hui-card-preview',
+].join(', ')
+
 /**
- * Waits for Home Assistant loading indicators to disappear.
+ * Decides whether the page has finished rendering and can be captured.
  *
- * Detects common HA loading patterns: circular progress spinners,
- * skeleton loaders, and loading placeholders.
+ * Runs inside the browser via page.waitForFunction, so it must stay
+ * self-contained: no imports, no module scope, no closures over anything here.
+ *
+ * An absence of loading indicators is not enough on its own. Home Assistant
+ * passes through several states that contain no indicator and no content
+ * either, and each one lasts longer the slower the instance is.
+ *
+ * @param selectors Comma-separated loading-indicator selectors
+ * @returns true when the page can be captured
+ */
+export function isPageReadyForCapture(selectors: string): boolean {
+  // Sits on the document root rather than in a shadow root, and is removed
+  // once the app has started.
+  if (document.getElementById('ha-launch-screen')) return false
+
+  const haEl = document.querySelector('home-assistant')
+  // Either not a Home Assistant page, or its root element is not defined yet.
+  if (!haEl?.shadowRoot) return true
+
+  const main = haEl.shadowRoot.querySelector('home-assistant-main') as
+    | (Element & { shadowRoot?: ShadowRoot | null })
+    | null
+  const resolver = main?.shadowRoot?.querySelector('partial-panel-resolver')
+  const panel = resolver?.firstElementChild as
+    | (Element & { _panelState?: string })
+    | null
+    | undefined
+  // The launch screen goes before a panel is mounted, leaving nothing to find.
+  if (!panel) return false
+  // Only the lovelace panel reports a load state.
+  if ('_panelState' in panel && panel._panelState !== 'loaded') return false
+
+  let pending = false
+  let expectedCards = 0
+  let renderedCards = 0
+
+  const scan = (root: ShadowRoot | Document): void => {
+    for (const el of Array.from(root.querySelectorAll(selectors))) {
+      const style = window.getComputedStyle(el)
+      if (style.display !== 'none' && style.visibility !== 'hidden') {
+        pending = true
+      }
+    }
+
+    for (const el of Array.from(root.querySelectorAll('*'))) {
+      if (el.tagName === 'HUI-CARD') renderedCards++
+
+      // A view lists the cards it will build before building them, so the
+      // panel can report itself loaded while the dashboard is still empty.
+      const declared = (el as Element & { _cards?: unknown })._cards
+      if (Array.isArray(declared)) expectedCards += declared.length
+
+      // Energy cards show a translated "Loading" string as plain text, with
+      // no element or class to match on, so their own fields are the only
+      // way to tell. The table and distribution cards use _data; the usage
+      // graph uses _chartData and draws bare axes until it has series. The
+      // date and period selectors carry neither and must not be waited on.
+      if (el.tagName.startsWith('HUI-ENERGY')) {
+        const card = el as Element & { _data?: unknown; _chartData?: unknown }
+        if ('_data' in el && card._data === undefined) pending = true
+        // A dashboard whose energy statistics are empty also has no series,
+        // so that case waits the full timeout before it is captured.
+        if (Array.isArray(card._chartData) && card._chartData.length === 0) {
+          pending = true
+        }
+      }
+
+      const shadow = (el as Element & { shadowRoot?: ShadowRoot | null })
+        .shadowRoot
+      if (shadow) scan(shadow)
+    }
+  }
+
+  scan(haEl.shadowRoot)
+
+  return !pending && renderedCards >= expectedCards
+}
+
+/**
+ * Waits for the page to finish rendering, up to a timeout.
  *
  * NOTE: Uses Puppeteer's waitForFunction instead of manual evaluate() polling.
  * The function is sent to the browser once and polled internally every 100ms,
@@ -206,70 +296,45 @@ export class WaitForLoadingComplete {
     this.#timeout = timeout
   }
 
-  /**
-   * Waits for loading indicators to disappear or timeout.
-   * @returns Actual wait time in milliseconds
-   */
+  /** @returns Actual wait time in milliseconds */
   async call(): Promise<number> {
     const start = Date.now()
 
-    const loadingSelectors = [
-      'ha-circular-progress',
-      'hass-loading-screen', // Panel loading screen (shown while _panelState === "loading")
-      '.loading',
-      '.spinner',
-      '[loading]',
-      'hui-card-preview', // Card preview placeholder
-    ].join(', ')
-
     try {
       await this.#page.waitForFunction(
-        (selectors: string) => {
-          // ha-launch-screen lives on document root (not in shadow DOM)
-          // It's removed when the app is fully initialized
-          if (document.getElementById('ha-launch-screen')) return false
-
-          const haEl = document.querySelector('home-assistant')
-          if (!haEl?.shadowRoot) return true // No HA element = nothing to wait for
-
-          const checkShadowRoot = (root: ShadowRoot | Document): boolean => {
-            const indicators = Array.from(root.querySelectorAll(selectors))
-            for (const el of indicators) {
-              const style = window.getComputedStyle(el)
-              if (style.display !== 'none' && style.visibility !== 'hidden') {
-                return true
-              }
-            }
-
-            const elementsWithShadow = Array.from(root.querySelectorAll('*'))
-            for (const el of elementsWithShadow) {
-              if ((el as Element & { shadowRoot?: ShadowRoot }).shadowRoot) {
-                if (
-                  checkShadowRoot(
-                    (el as Element & { shadowRoot: ShadowRoot }).shadowRoot,
-                  )
-                ) {
-                  return true
-                }
-              }
-            }
-
-            return false
-          }
-
-          // Return true (ready) when no visible loading indicators remain
-          return !checkShadowRoot(haEl.shadowRoot)
-        },
+        isPageReadyForCapture,
         { timeout: this.#timeout, polling: 100 },
-        loadingSelectors,
+        LOADING_SELECTORS,
       )
     } catch (_err) {
-      log.debug`Loading indicator timeout after ${Date.now() - start}ms`
+      log.debug`Page readiness timed out after ${Date.now() - start}ms`
     }
 
+    await this.#warnIfInternalsMissing()
+
     const actualWait = Date.now() - start
-    log.debug`Loading indicators cleared after ${actualWait}ms`
+    log.debug`Page ready after ${actualWait}ms`
     return actualWait
+  }
+
+  /**
+   * Reports, once per process, that the readiness check has stopped checking
+   * anything. Without this the add-on would quietly go back to capturing
+   * half-drawn dashboards after a Home Assistant upgrade.
+   */
+  async #warnIfInternalsMissing(): Promise<void> {
+    if (warnedAboutInternals) return
+
+    let present = true
+    try {
+      present = await this.#page.evaluate(readinessInternalsPresent)
+    } catch (_err) {
+      return // Page closed or navigated away.
+    }
+    if (present) return
+
+    warnedAboutInternals = true
+    log.warn`This version of Home Assistant no longer reports when a dashboard has finished drawing, so screenshots may be captured before cards have filled in. Please report this along with your Home Assistant version.`
   }
 }
 
@@ -318,6 +383,41 @@ export class DismissToasts {
       return dismissed
     })
   }
+}
+
+/**
+ * Reports whether the Home Assistant fields isPageReadyForCapture depends on
+ * are still there. They are private to the frontend and a release is free to
+ * rename them, at which point the readiness check starts passing everything.
+ *
+ * Runs inside the browser, so it must stay self-contained.
+ *
+ * @returns false only when a lovelace panel is missing those fields
+ */
+export function readinessInternalsPresent(): boolean {
+  const haEl = document.querySelector('home-assistant')
+  if (!haEl?.shadowRoot) return true
+
+  const main = haEl.shadowRoot.querySelector('home-assistant-main') as
+    | (Element & { shadowRoot?: ShadowRoot | null })
+    | null
+  const resolver = main?.shadowRoot?.querySelector('partial-panel-resolver')
+  const panel = resolver?.firstElementChild
+  // Only the lovelace panel exposes these; other panels never had them.
+  if (panel?.tagName !== 'HA-PANEL-LOVELACE') return true
+  if (!('_panelState' in panel)) return false
+
+  let sawDeclaredCards = false
+  const walk = (root: ShadowRoot | Document): void => {
+    for (const el of Array.from(root.querySelectorAll('*'))) {
+      if ('_cards' in el) sawDeclaredCards = true
+      const shadow = (el as Element & { shadowRoot?: ShadowRoot | null })
+        .shadowRoot
+      if (shadow) walk(shadow)
+    }
+  }
+  walk(haEl.shadowRoot)
+  return sawDeclaredCards
 }
 
 /**

--- a/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
+++ b/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
@@ -325,13 +325,11 @@ export class WaitForLoadingComplete {
   async #warnIfInternalsMissing(): Promise<void> {
     if (warnedAboutInternals) return
 
-    let present = true
     try {
-      present = await this.#page.evaluate(readinessInternalsPresent)
+      if (await this.#page.evaluate(readinessInternalsPresent)) return
     } catch (_err) {
       return // Page closed or navigated away.
     }
-    if (present) return
 
     warnedAboutInternals = true
     log.warn`This version of Home Assistant no longer reports when a dashboard has finished drawing, so screenshots may be captured before cards have filled in. Please report this along with your Home Assistant version.`

--- a/trmnl-ha/ha-trmnl/lib/dithering.ts
+++ b/trmnl-ha/ha-trmnl/lib/dithering.ts
@@ -594,8 +594,7 @@ export async function applyDithering(
 
   // Log output size
   const sizeKB = (buffer.length / 1024).toFixed(1)
-  const status = buffer.length > 50 * 1024 ? '⚠️ OVER 50KB' : '✓'
-  log.info`Output: ${buffer.length} bytes (${sizeKB}KB) ${status} [depth:${
+  log.info`Output: ${buffer.length} bytes (${sizeKB}KB) [depth:${
     bitDepth ?? 'auto'
   }, compression:${compressionLevel}]`
 

--- a/trmnl-ha/ha-trmnl/screenshot.ts
+++ b/trmnl-ha/ha-trmnl/screenshot.ts
@@ -18,7 +18,6 @@
 import puppeteer from 'puppeteer'
 import type {
   Browser as PuppeteerBrowser,
-  ConsoleMessage,
   Page,
   Viewport,
 } from 'puppeteer'
@@ -137,7 +136,7 @@ export interface NavigateParams {
   /** Full target URL (if provided, overrides pagePath + base URL resolution) */
   targetUrl?: string
   viewport: Viewport
-  /** Fixed wait time in ms. If omitted, waits for loading indicators to clear. */
+  /** Settling time in ms, added after the page reports itself ready. */
   extraWait?: number
   zoom?: number
   lang?: string
@@ -313,6 +312,12 @@ export class Browser {
     // Create fresh page
     try {
       const page = await timed('browser.newPage', () => this.#browser!.newPage())
+      // Charts grow their bars from zero when data arrives, so a capture taken
+      // during that would show empty axes. An e-ink display cannot show
+      // animation in any case.
+      await page.emulateMediaFeatures([
+        { name: 'prefers-reduced-motion', value: 'reduce' },
+      ])
       this.#setupPageLogging(page)
       this.#page = page
       return this.#page
@@ -427,42 +432,8 @@ export class Browser {
     const start = Date.now()
     this.#busy = true
     try {
-      // home-assistant-js-websocket's subscribeMessage() has a microtask race
-      // between handler registration and incoming WS frames. When the server's
-      // response arrives faster than the registration microtask completes
-      // (notably on cold cache where RTT is ~15ms vs ~38ms warm), HA logs
-      // "Received event for unknown subscription N. Unsubscribing." and drops
-      // the forecast/render-template data. The card never re-subscribes, so
-      // forecast renders empty.
-      //
-      // Retry strategy on detection:
-      //   - Attempt 1 is always a full fresh-page navigation (the per-request
-      //     reset that issue #34 mandates).
-      //   - Attempts 2..N reuse the live page and re-mount the panel via an
-      //     in-app router transition (pushState to '/', then back to the
-      //     target). The WebSocket connection stays open and the JS heap
-      //     stays hot, which is what actually makes the race stop losing.
-      //     Closing and re-creating the page on each retry would throw away
-      //     the warmth we need.
-      //
-      // Cost is paid only on attempts that detect the orphan warning;
-      // dashboards built from REST/static cards (no subscribeMessage calls)
-      // never trigger the retry path.
-      const MAX_ATTEMPTS = 5
-      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-        const orphaned = await this.#runNavigationAttempt(params, attempt === 1)
-        if (!orphaned) {
-          recordTiming('nav.total', Date.now() - start)
-          return { time: Date.now() - start }
-        }
-        if (attempt === MAX_ATTEMPTS) {
-          log.warn`HA WS subscription race persisted after ${MAX_ATTEMPTS} attempts; some card data may be missing from this screenshot`
-          recordTiming('nav.total', Date.now() - start)
-          return { time: Date.now() - start }
-        }
-        log.info`HA WS subscription race detected on attempt ${attempt}; soft-retrying via in-page router transition`
-      }
-      // Loop always returns or throws; this is unreachable.
+      await this.#runNavigation(params)
+      recordTiming('nav.total', Date.now() - start)
       return { time: Date.now() - start }
     } finally {
       this.#busy = false
@@ -470,80 +441,34 @@ export class Browser {
   }
 
   /**
-   * Runs a single navigation attempt and reports whether the HA WS
-   * subscription race was observed during the run. Throws on hard errors
-   * (browser crash, navigation failure) so the retry loop does not mask them.
-   *
-   * @param freshPage true to discard the current page and do a full
-   *   page.goto() (the per-request reset); false to reuse the live page and
-   *   re-mount the panel via an in-app router transition (used by retries).
-   * @returns true if a "Received event for unknown subscription" console
-   *   warning fired during this attempt, false otherwise.
+   * Navigates to the target page and runs the readiness pipeline.
+   * Throws on hard errors (browser crash, navigation failure).
    */
-  async #runNavigationAttempt(
-    {
-      pagePath,
-      targetUrl,
-      viewport,
-      extraWait,
-      zoom = 1,
-      lang,
-      theme,
-      dark,
-    }: NavigateParams,
-    freshPage: boolean,
-  ): Promise<boolean> {
-    let orphanDetected = false
-    let consoleHandler: ((msg: ConsoleMessage) => void) | undefined
-    let listeningPage: Page | undefined
-
+  async #runNavigation({
+    pagePath,
+    targetUrl,
+    viewport,
+    extraWait,
+    zoom = 1,
+    lang,
+    theme,
+    dark,
+  }: NavigateParams): Promise<void> {
     try {
-      if (freshPage) {
-        // Fresh page per request: close existing page to eliminate accumulated
-        // stale state (WebSocket connections, cached renders, component state)
-        await this.#closePage()
-      }
+      // Fresh page per request: close existing page to eliminate accumulated
+      // stale state (WebSocket connections, cached renders, component state)
+      await this.#closePage()
 
       const page = await this.#getPage()
-      if (freshPage) {
-        await page.setViewport(viewport)
-      }
+      await page.setViewport(viewport)
 
-      // Listen for the orphaned-subscription console warning that signals
-      // the HA WS subscribeMessage race. Attaching here (after #getPage)
-      // catches warnings from the entire navigation, including card-mount
-      // subscribes triggered by pushState.
-      consoleHandler = (msg) => {
-        // Puppeteer 24+ returns 'warn'; older versions returned 'warning'.
-        // Accept both (as string — 'warning' left the type union) so we
-        // don't break if puppeteer's enum shifts again.
-        const type: string = msg.type()
-        if (
-          (type === 'warn' || type === 'warning') &&
-          msg.text().includes('Received event for unknown subscription')
-        ) {
-          orphanDetected = true
-        }
-      }
-      page.on('console', consoleHandler)
-      listeningPage = page
-
-      if (freshPage) {
-        // First attempt: full fresh navigation — injects auth, full page.goto()
-        const authStorage = this.#buildAuthStorage()
-        const navigateCmd = new NavigateToPage(
-          page,
-          authStorage,
-          this.#homeAssistantUrl,
-        )
-        await timed('nav.goto', () => navigateCmd.call(pagePath, targetUrl))
-      } else {
-        // Warm retry: re-mount the panel via SPA pushState on the live page.
-        // WS connection, JS heap, and auth all carry over from attempt 1.
-        await timed('nav.softReroute', () =>
-          this.#softReroute(page, pagePath, targetUrl),
-        )
-      }
+      const authStorage = this.#buildAuthStorage()
+      const navigateCmd = new NavigateToPage(
+        page,
+        authStorage,
+        this.#homeAssistantUrl,
+      )
+      await timed('nav.goto', () => navigateCmd.call(pagePath, targetUrl))
 
       // Check if we landed on HA login/auth page (indicates invalid token)
       const currentUrl = page.url()
@@ -576,51 +501,53 @@ export class Browser {
         this.#lastRequestedDarkMode = dark
       }
 
-      // Wait strategy: explicit fixed wait OR multi-stage readiness detection
+      // An explicit wait adds to these stages rather than replacing them, so
+      // it can lengthen a capture but never shorten the checks.
       // NOTE: page.goto() already uses waitUntil:'networkidle2' so network is settled
+
+      // Stage 1: Wait for network to re-settle after theme/language changes
+      // Theme and language changes trigger WebSocket messages and cascading renders
+      if (setupResult.themeChanged || setupResult.langChanged) {
+        log.debug`Waiting for network idle after page setup changes`
+        try {
+          await timed('nav.waitNetworkIdle', () =>
+            page.waitForNetworkIdle({ idleTime: 500, concurrency: 2 }),
+          )
+        } catch (_err) {
+          log.debug`Network idle wait timed out after page setup`
+        }
+      }
+
+      // Stage 2: Wait for HA entity data to load (HA pages only)
+      if (!isGenericUrl) {
+        const hassReadyCmd = new WaitForHassReady(page)
+        await timed('nav.waitHassReady', () => hassReadyCmd.call())
+      }
+
+      // Stage 3: Wait for the dashboard to finish drawing
+      const loadingCmd = new WaitForLoadingComplete(page, 15000)
+      const loadingWait = await timed('nav.waitLoading', () =>
+        loadingCmd.call(),
+      )
+      log.debug`Dashboard ready after ${loadingWait}ms`
+
+      // Stage 4: Dismiss notification toasts (HA pages only)
+      if (!isGenericUrl) {
+        const dismissCmd = new DismissToasts(page)
+        const count = await timed('nav.dismissToasts', () => dismissCmd.call())
+        if (count > 0) log.debug`Dismissed ${count} notification toast(s)`
+      }
+
+      // Stage 5: Wait for rendering pipeline to flush
+      const paintCmd = new WaitForPaintStability(page)
+      await timed('nav.waitPaint', () => paintCmd.call())
+
+      // Stage 6: Extra settling time for cards that fill in late
       if (extraWait && extraWait > 0) {
         log.debug`Explicit wait: ${extraWait}ms`
         await new Promise((resolve) => setTimeout(resolve, extraWait))
-      } else {
-        // Stage 1: Wait for network to re-settle after theme/language changes
-        // Theme and language changes trigger WebSocket messages and cascading renders
-        if (setupResult.themeChanged || setupResult.langChanged) {
-          log.debug`Waiting for network idle after page setup changes`
-          try {
-            await timed('nav.waitNetworkIdle', () =>
-              page.waitForNetworkIdle({ idleTime: 500, concurrency: 2 }),
-            )
-          } catch (_err) {
-            log.debug`Network idle wait timed out after page setup`
-          }
-        }
-
-        // Stage 2: Wait for HA entity data to load (HA pages only)
-        if (!isGenericUrl) {
-          const hassReadyCmd = new WaitForHassReady(page)
-          await timed('nav.waitHassReady', () => hassReadyCmd.call())
-        }
-
-        // Stage 3: Wait for loading indicators to clear
-        const loadingCmd = new WaitForLoadingComplete(page, 15000)
-        const loadingWait = await timed('nav.waitLoading', () =>
-          loadingCmd.call(),
-        )
-        log.debug`Loading indicators cleared after ${loadingWait}ms`
-
-        // Stage 4: Dismiss notification toasts (HA pages only)
-        if (!isGenericUrl) {
-          const dismissCmd = new DismissToasts(page)
-          const count = await timed('nav.dismissToasts', () => dismissCmd.call())
-          if (count > 0) log.debug`Dismissed ${count} notification toast(s)`
-        }
-
-        // Stage 5: Wait for rendering pipeline to flush
-        const paintCmd = new WaitForPaintStability(page)
-        await timed('nav.waitPaint', () => paintCmd.call())
       }
 
-      return orphanDetected
     } catch (err) {
       this.#pageErrorDetected = false
 
@@ -641,53 +568,7 @@ export class Browser {
       }
 
       throw err
-    } finally {
-      // Detach the orphan listener so listeners don't accumulate across
-      // retries / subsequent screenshots. Page may be closed already; ignore.
-      if (consoleHandler && listeningPage) {
-        try {
-          listeningPage.off('console', consoleHandler)
-        } catch (_err) {
-          /* page closed */
-        }
-      }
     }
-  }
-
-  /**
-   * Re-mounts the panel on the live page by routing to '/' and then back to
-   * the target path via pushState + popstate. Used by retries instead of a
-   * fresh page.goto() so the existing WebSocket connection and JS heap are
-   * preserved — those are the actual carriers of "warmth" that win the
-   * subscribeMessage race on slow hardware.
-   */
-  async #softReroute(
-    page: Page,
-    pagePath: string,
-    targetUrl?: string,
-  ): Promise<void> {
-    const pageUrl =
-      targetUrl || new URL(pagePath, this.#homeAssistantUrl).toString()
-    const u = new URL(pageUrl)
-    const targetPath = u.pathname + u.search
-
-    // Unmount the current panel by routing to '/'
-    await page.evaluate(() => {
-      history.pushState(null, '', '/')
-      window.dispatchEvent(new PopStateEvent('popstate'))
-    })
-
-    // Brief settle so HA's partial-panel-resolver tears down the panel
-    // before we route back. Without this, the back-transition can merge
-    // with the unmount and skip a full remount cycle.
-    await new Promise((resolve) => setTimeout(resolve, 300))
-
-    // Route back to the target path; cards re-mount and re-subscribe on
-    // top of the live connection.
-    await page.evaluate((path: string) => {
-      history.pushState(null, '', path)
-      window.dispatchEvent(new PopStateEvent('popstate'))
-    }, targetPath)
   }
 
   /**

--- a/trmnl-ha/ha-trmnl/tests/unit/navigation-commands.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/navigation-commands.test.ts
@@ -16,6 +16,8 @@ import {
   WaitForHassReady,
   UpdateLanguage,
   UpdateTheme,
+  isPageReadyForCapture,
+  readinessInternalsPresent,
   type AuthStorage,
 } from '../../lib/browser/navigation-commands.js'
 import { CannotOpenPageError } from '../../error.js'
@@ -816,5 +818,300 @@ describe('UpdateTheme', () => {
       theme: '',
       dark: false,
     })
+  })
+})
+
+// =============================================================================
+// Fake DOM
+//
+// isPageReadyForCapture and readinessInternalsPresent are shipped to the
+// browser by page.evaluate, so they read globals rather than take a tree as an
+// argument. These fakes supply the few DOM methods they use.
+// =============================================================================
+
+interface FakeEl {
+  tagName: string
+  /** Selectors this element answers to, since the fake does not parse CSS. */
+  matches?: string[]
+  shadowRoot?: FakeEl | null
+  children?: FakeEl[]
+  hidden?: boolean
+  _panelState?: string
+  _cards?: unknown[]
+  _data?: unknown
+  _chartData?: unknown
+}
+
+interface FakeNode extends FakeEl {
+  shadowRoot: FakeNode | null
+  firstElementChild: FakeNode | null
+  querySelector: (s: string) => FakeNode | null
+  querySelectorAll: (s: string) => FakeNode[]
+}
+
+function node(el: FakeEl): FakeNode {
+  const children = (el.children ?? []).map(node)
+  const descendants = children.flatMap((c) => [c, ...c.querySelectorAll('*')])
+
+  const querySelectorAll = (sel: string): FakeNode[] => {
+    if (sel === '*') return descendants
+    const wanted = sel.split(',').map((s) => s.trim())
+    return descendants.filter((d) =>
+      (d.matches ?? []).some((m) => wanted.includes(m)),
+    )
+  }
+
+  return {
+    ...el,
+    children,
+    shadowRoot: el.shadowRoot ? node(el.shadowRoot) : null,
+    firstElementChild: children[0] ?? null,
+    querySelectorAll,
+    querySelector: (sel) => querySelectorAll(sel)[0] ?? null,
+  }
+}
+
+function installDom(opts: { launchScreen?: boolean; root?: FakeEl | null }) {
+  const root = opts.root ? node(opts.root) : null
+  const globals = globalThis as unknown as {
+    document: unknown
+    window: unknown
+  }
+  globals.document = {
+    getElementById: (id: string) =>
+      id === 'ha-launch-screen' && opts.launchScreen ? {} : null,
+    querySelector: (sel: string) => (sel === 'home-assistant' ? root : null),
+  }
+  globals.window = {
+    getComputedStyle: (el: FakeNode) =>
+      el.hidden
+        ? { display: 'none', visibility: 'hidden' }
+        : { display: 'block', visibility: 'visible' },
+  }
+}
+
+/** home-assistant tree with the given panel mounted in partial-panel-resolver. */
+function haWith(panel: FakeEl | null): FakeEl {
+  return {
+    tagName: 'HOME-ASSISTANT',
+    shadowRoot: {
+      tagName: '#shadow',
+      children: [
+        {
+          tagName: 'HOME-ASSISTANT-MAIN',
+          matches: ['home-assistant-main'],
+          shadowRoot: {
+            tagName: '#shadow',
+            children: [
+              {
+                tagName: 'PARTIAL-PANEL-RESOLVER',
+                matches: ['partial-panel-resolver'],
+                children: panel ? [panel] : [],
+              },
+            ],
+          },
+        },
+      ],
+    },
+  }
+}
+
+/** A loaded lovelace panel containing the given cards. */
+function lovelaceWith(cards: FakeEl[]): FakeEl {
+  return haWith({
+    tagName: 'HA-PANEL-LOVELACE',
+    _panelState: 'loaded',
+    children: cards,
+  })
+}
+
+/** A loaded lovelace panel whose view declares cards but has rendered some. */
+function viewWith(declared: number, rendered: number): FakeEl {
+  return lovelaceWith([
+    {
+      tagName: 'HUI-VIEW',
+      _cards: Array.from({ length: declared }, () => ({})),
+      children: Array.from({ length: rendered }, () => ({
+        tagName: 'HUI-CARD',
+      })),
+    },
+  ])
+}
+
+const SPINNER: FakeEl = {
+  tagName: 'HA-CIRCULAR-PROGRESS',
+  matches: ['ha-circular-progress'],
+}
+
+// =============================================================================
+// isPageReadyForCapture
+// =============================================================================
+
+describe('isPageReadyForCapture', () => {
+  const selectors =
+    'ha-circular-progress, hass-loading-screen, .loading, .spinner, [loading], hui-card-preview'
+
+  const ready = (): boolean => isPageReadyForCapture(selectors)
+
+  it('captures a page that has no home-assistant element', () => {
+    installDom({ root: null })
+
+    expect(ready()).toBe(true)
+  })
+
+  describe('start up', () => {
+    it('waits while the launch screen is up', () => {
+      installDom({ launchScreen: true, root: lovelaceWith([]) })
+
+      expect(ready()).toBe(false)
+    })
+
+    it('waits after the launch screen goes but before a panel mounts', () => {
+      installDom({ root: haWith(null) })
+
+      expect(ready()).toBe(false)
+    })
+
+    it('waits while the lovelace panel reports itself loading', () => {
+      installDom({
+        root: haWith({ tagName: 'HA-PANEL-LOVELACE', _panelState: 'loading' }),
+      })
+
+      expect(ready()).toBe(false)
+    })
+
+    it('captures panels that report no load state', () => {
+      installDom({ root: haWith({ tagName: 'HA-PANEL-HISTORY' }) })
+
+      expect(ready()).toBe(true)
+    })
+  })
+
+  describe('loading indicators', () => {
+    it('waits while one is visible', () => {
+      installDom({ root: lovelaceWith([SPINNER]) })
+
+      expect(ready()).toBe(false)
+    })
+
+    it('captures when the only one is hidden', () => {
+      installDom({ root: lovelaceWith([{ ...SPINNER, hidden: true }]) })
+
+      expect(ready()).toBe(true)
+    })
+  })
+
+  describe('cards a view has yet to render', () => {
+    it('waits while any are outstanding', () => {
+      installDom({ root: viewWith(3, 0) })
+
+      expect(ready()).toBe(false)
+    })
+
+    it('captures once all are rendered', () => {
+      installDom({ root: viewWith(2, 2) })
+
+      expect(ready()).toBe(true)
+    })
+
+    it('captures a dashboard that declares none', () => {
+      installDom({ root: viewWith(0, 0) })
+
+      expect(ready()).toBe(true)
+    })
+  })
+
+  describe('energy cards', () => {
+    it('waits on one holding no data', () => {
+      installDom({
+        root: lovelaceWith([
+          { tagName: 'HUI-ENERGY-SOURCES-TABLE-CARD', _data: undefined },
+        ]),
+      })
+
+      expect(ready()).toBe(false)
+    })
+
+    it('captures once it has data', () => {
+      installDom({
+        root: lovelaceWith([
+          { tagName: 'HUI-ENERGY-SOURCES-TABLE-CARD', _data: { stats: [] } },
+        ]),
+      })
+
+      expect(ready()).toBe(true)
+    })
+
+    it('waits on a usage graph holding no series', () => {
+      installDom({
+        root: lovelaceWith([
+          { tagName: 'HUI-ENERGY-USAGE-GRAPH-CARD', _chartData: [] },
+        ]),
+      })
+
+      expect(ready()).toBe(false)
+    })
+
+    it('captures once the usage graph has its series', () => {
+      installDom({
+        root: lovelaceWith([
+          { tagName: 'HUI-ENERGY-USAGE-GRAPH-CARD', _chartData: [{}, {}] },
+        ]),
+      })
+
+      expect(ready()).toBe(true)
+    })
+
+    it('captures alongside energy elements that hold neither', () => {
+      installDom({
+        root: lovelaceWith([
+          { tagName: 'HUI-ENERGY-DATE-SELECTION-CARD' },
+          { tagName: 'HUI-ENERGY-PERIOD-SELECTOR' },
+        ]),
+      })
+
+      expect(ready()).toBe(true)
+    })
+  })
+})
+
+// =============================================================================
+// readinessInternalsPresent
+// =============================================================================
+
+describe('readinessInternalsPresent', () => {
+  it('passes a page that has no home-assistant element', () => {
+    installDom({ root: null })
+
+    expect(readinessInternalsPresent()).toBe(true)
+  })
+
+  it('passes a panel that never carried these fields', () => {
+    installDom({ root: haWith({ tagName: 'HA-PANEL-HISTORY' }) })
+
+    expect(readinessInternalsPresent()).toBe(true)
+  })
+
+  it('passes lovelace while both fields are there', () => {
+    installDom({ root: viewWith(0, 0) })
+
+    expect(readinessInternalsPresent()).toBe(true)
+  })
+
+  it('fails when the lovelace panel drops its load state', () => {
+    installDom({
+      root: haWith({
+        tagName: 'HA-PANEL-LOVELACE',
+        children: [{ tagName: 'HUI-VIEW', _cards: [] }],
+      }),
+    })
+
+    expect(readinessInternalsPresent()).toBe(false)
+  })
+
+  it('fails when no view declares its cards', () => {
+    installDom({ root: lovelaceWith([{ tagName: 'HUI-VIEW' }]) })
+
+    expect(readinessInternalsPresent()).toBe(false)
   })
 })

--- a/trmnl-ha/ha-trmnl/tests/unit/navigation-commands.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/navigation-commands.test.ts
@@ -457,6 +457,25 @@ describe('WaitForPageLoad', () => {
 // =============================================================================
 
 describe('WaitForLoadingComplete', () => {
+  // The warning latches for the life of the process, so this has to run
+  // before anything else in the suite drives a page whose evaluate() reports
+  // the internals as missing.
+  it('checks the Home Assistant internals once and not again', async () => {
+    let checks = 0
+    const missingInternals = {
+      waitForFunction: async () => {},
+      evaluate: async () => {
+        checks++
+        return false
+      },
+    } as unknown as Page
+
+    await new WaitForLoadingComplete(missingInternals, 10).call()
+    await new WaitForLoadingComplete(missingInternals, 10).call()
+
+    expect(checks).toBe(1)
+  })
+
   it('returns wait time when resolved immediately', async () => {
     const mockPage = {
       waitForFunction: async () => {},

--- a/trmnl-ha/ha-trmnl/tests/unit/screenshot-clip.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/screenshot-clip.test.ts
@@ -18,6 +18,7 @@
 
 import { mock, describe, it, expect, beforeEach } from 'bun:test'
 import type { BrowserDeps } from '../../screenshot.js'
+import { readinessInternalsPresent } from '../../lib/browser/navigation-commands.js'
 
 // Safety: const.ts needs these env vars at module load time (no options-dev.json in CI)
 process.env['HOME_ASSISTANT_URL'] = 'http://localhost:8123'
@@ -85,8 +86,12 @@ function createMockPage(): MockPage {
     evaluateOnNewDocument: mock(async () => ({ identifier: 'mock-id' })),
     goto: mock(async () => ({ ok: () => true, status: () => 200 })),
     removeScriptToEvaluateOnNewDocument: mock(async () => {}),
-    // Wait commands + page setup strategies
-    evaluate: mock(async () => 0),
+    // Wait commands + page setup strategies. The readiness check asks whether
+    // Home Assistant still exposes the fields it depends on, and must be told
+    // yes; every other caller here reads a count.
+    evaluate: mock(async (fn: unknown) =>
+      fn === readinessInternalsPresent ? true : 0,
+    ),
     waitForFunction: mock(async () => {}),
     fireConsole: (text: string, type: string = 'warn') => {
       const msg = { type: () => type, text: () => text }

--- a/trmnl-ha/ha-trmnl/tests/unit/screenshot-clip.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/screenshot-clip.test.ts
@@ -16,7 +16,7 @@
  * @module tests/unit/screenshot-clip
  */
 
-import { mock, describe, it, expect, beforeEach, afterAll } from 'bun:test'
+import { mock, describe, it, expect, beforeEach } from 'bun:test'
 import type { BrowserDeps } from '../../screenshot.js'
 
 // Safety: const.ts needs these env vars at module load time (no options-dev.json in CI)
@@ -32,6 +32,7 @@ type MockFn = ReturnType<typeof mock>
 interface MockPage {
   screenshot: MockFn
   setViewport: MockFn
+  emulateMediaFeatures: MockFn
   close: MockFn
   on: MockFn
   off: MockFn
@@ -52,7 +53,7 @@ let currentMockPage: MockPage
 
 function createMockPage(): MockPage {
   // Map from event name to list of handlers. Tests can fire 'console' events
-  // via fireConsole() to exercise the orphan-detection retry path.
+  // via fireConsole() to check that page warnings stay inert.
   const handlers = new Map<string, ((arg: unknown) => void)[]>()
 
   const page: MockPage = {
@@ -61,6 +62,7 @@ function createMockPage(): MockPage {
         new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]),
     ),
     setViewport: mock(async (_v?: unknown) => {}),
+    emulateMediaFeatures: mock(async (_f?: unknown) => {}),
     close: mock(async () => {}),
     url: () => 'http://localhost:8123/lovelace',
     waitForNetworkIdle: mock(async () => {}),
@@ -301,202 +303,43 @@ describe('Browser', () => {
       expect(typeof result.time).toBe('number')
     })
 
-    // ------------------------------------------------------------------------
-    // Retry on HA WS subscribeMessage race
-    //
-    // home-assistant-js-websocket has a microtask race between subscribe
-    // handler registration and incoming WS frames. When triggered, HA logs
-    // "Received event for unknown subscription N" and drops forecast data.
-    // The orphan-detector listens for these warnings and retries by re-mounting
-    // the panel via in-page SPA pushState on the same live page (warm WS
-    // connection + warm JS heap is what wins the race on slow hardware).
-    // Attempt 1 is always a fresh page.goto(); attempts 2..N reuse the page.
-    // ------------------------------------------------------------------------
+    // The HA frontend logs "Received event for unknown subscription N" whenever
+    // an event arrives for an already-unsubscribed id, which happens routinely
+    // on panel unmount. Navigation must treat it as noise: a previous version
+    // retried on it by re-mounting the panel, which remounted the wrong
+    // dashboard and blanked energy/auto-entities cards (issues #84, #87).
+    it('does not renavigate when HA logs an orphan subscription warning', async () => {
+      const browser = new Browser(BASE_URL, TOKEN, mockDeps)
+      mockBrowserInstance.newPage.mockClear()
 
-    describe('retry on WS subscription race', () => {
-      // These tests override mockBrowserInstance.newPage.mockImplementation
-      // to inject console-warning triggers. Restore the default after the
-      // block so #screenshotPage tests below get plain pages.
-      afterAll(() => {
-        mockBrowserInstance.newPage.mockClear()
-        mockBrowserInstance.newPage.mockImplementation(async () =>
-          createMockPage(),
-        )
-      })
-
-      // Wrap a fresh page's goto() so it fires a chosen console warning AFTER
-      // the navigation handler has been attached. Used to trigger the orphan
-      // on attempt 1 (the only attempt that calls goto).
-      function makePageWithGotoTrigger(
-        text: string,
-        type: string = 'warn',
-      ): MockPage {
+      let pageCreatedCount = 0
+      mockBrowserInstance.newPage.mockImplementation(async () => {
+        pageCreatedCount++
         const page = createMockPage()
         const origGoto = page.goto
         page.goto = mock(async (url: string) => {
           const result = await origGoto(url)
-          page.fireConsole(text, type)
+          page.fireConsole(
+            'Received event for unknown subscription 42. Unsubscribing.',
+            'warn',
+          )
           return result
         }) as MockFn
         return page
-      }
-
-      // Wrap both goto() and evaluate() so the orphan warning fires on
-      // attempt 1 (via goto) AND every soft-retry (via softReroute's
-      // pushState evaluate calls). Used to exercise the MAX_ATTEMPTS cap.
-      function makePagePersistentlyOrphaning(
-        text: string,
-        type: string = 'warn',
-      ): MockPage {
-        const page = makePageWithGotoTrigger(text, type)
-        const origEvaluate = page.evaluate
-        page.evaluate = mock(
-          async (fn: (...args: unknown[]) => unknown, ...args: unknown[]) => {
-            const result = await origEvaluate(fn, ...args)
-            page.fireConsole(text, type)
-            return result
-          },
-        ) as MockFn
-        return page
-      }
-
-      it('soft-retries on the same page when an orphan warning fires', async () => {
-        const browser = new Browser(BASE_URL, TOKEN, mockDeps)
-        mockBrowserInstance.newPage.mockClear()
-
-        let pageCreatedCount = 0
-        mockBrowserInstance.newPage.mockImplementation(async () => {
-          pageCreatedCount++
-          // First (and only) page created: orphans on goto, succeeds on
-          // soft-retry (softReroute uses evaluate, not goto, so the trigger
-          // doesn't re-fire).
-          return makePageWithGotoTrigger(
-            'Received event for unknown subscription 42. Unsubscribing.',
-          )
-        })
-
-        const result = await browser.navigatePage({
-          pagePath: '/lovelace/0',
-          viewport: DEFAULT_VIEWPORT,
-        })
-
-        // Soft retry reuses the same page — only one newPage() call total.
-        expect(pageCreatedCount).toBe(1)
-        // goto called exactly once (attempt 1); retry used pushState evaluate.
-        expect(currentMockPage.goto).toHaveBeenCalledTimes(1)
-        expect(typeof result.time).toBe('number')
       })
 
-      it('does NOT retry when no orphan warning fires', async () => {
-        const browser = new Browser(BASE_URL, TOKEN, mockDeps)
-        mockBrowserInstance.newPage.mockClear()
-
-        let pageCreatedCount = 0
-        mockBrowserInstance.newPage.mockImplementation(async () => {
-          pageCreatedCount++
-          return createMockPage()
-        })
-
-        await browser.navigatePage({
-          pagePath: '/lovelace/0',
-          viewport: DEFAULT_VIEWPORT,
-        })
-
-        expect(pageCreatedCount).toBe(1)
+      await browser.navigatePage({
+        pagePath: '/lovelace/0',
+        viewport: DEFAULT_VIEWPORT,
       })
 
-      it('caps retries at MAX_ATTEMPTS (no infinite loop on persistent race)', async () => {
-        const browser = new Browser(BASE_URL, TOKEN, mockDeps)
-        mockBrowserInstance.newPage.mockClear()
+      expect(pageCreatedCount).toBe(1)
+      expect(currentMockPage.goto).toHaveBeenCalledTimes(1)
+      expect(browser.busy).toBe(false)
 
-        // Every attempt orphans (goto on attempt 1, evaluate on each retry).
-        // Verify we still return after the cap and never create extra pages.
-        // Cap matches the MAX_ATTEMPTS constant in screenshot.ts (currently 5).
-        let pageCreatedCount = 0
-        mockBrowserInstance.newPage.mockImplementation(async () => {
-          pageCreatedCount++
-          return makePagePersistentlyOrphaning(
-            'Received event for unknown subscription 1. Unsubscribing.',
-          )
-        })
-
-        const result = await browser.navigatePage({
-          pagePath: '/lovelace/0',
-          viewport: DEFAULT_VIEWPORT,
-        })
-
-        // Still only one page across all soft retries.
-        expect(pageCreatedCount).toBe(1)
-        // goto called exactly once (only attempt 1 does a hard navigation).
-        expect(currentMockPage.goto).toHaveBeenCalledTimes(1)
-        // 'console' subscribed once by #setupPageLogging plus once per
-        // attempt — exactly MAX_ATTEMPTS (5) attempts ran, then we stopped.
-        const consoleSubscriptions = currentMockPage.on.mock.calls.filter(
-          (call) => call[0] === 'console',
-        ).length
-        expect(consoleSubscriptions).toBe(6)
-        expect(typeof result.time).toBe('number')
-      })
-
-      it('ignores non-orphan console warnings', async () => {
-        const browser = new Browser(BASE_URL, TOKEN, mockDeps)
-        mockBrowserInstance.newPage.mockClear()
-
-        let pageCreatedCount = 0
-        mockBrowserInstance.newPage.mockImplementation(async () => {
-          pageCreatedCount++
-          return makePageWithGotoTrigger('Some unrelated browser warning')
-        })
-
-        await browser.navigatePage({
-          pagePath: '/lovelace/0',
-          viewport: DEFAULT_VIEWPORT,
-        })
-
-        // No retry — only 1 page.
-        expect(pageCreatedCount).toBe(1)
-      })
-
-      it('ignores orphan-like warnings of non-warning type', async () => {
-        // Detector only matches type() === 'warn' | 'warning'. An 'info' or
-        // 'log' message with similar text shouldn't trigger a retry.
-        const browser = new Browser(BASE_URL, TOKEN, mockDeps)
-        mockBrowserInstance.newPage.mockClear()
-
-        let pageCreatedCount = 0
-        mockBrowserInstance.newPage.mockImplementation(async () => {
-          pageCreatedCount++
-          return makePageWithGotoTrigger(
-            'Received event for unknown subscription 7. Unsubscribing.',
-            'info',
-          )
-        })
-
-        await browser.navigatePage({
-          pagePath: '/lovelace/0',
-          viewport: DEFAULT_VIEWPORT,
-        })
-
-        expect(pageCreatedCount).toBe(1)
-      })
-
-      it('keeps #busy=false after a retried navigation completes', async () => {
-        const browser = new Browser(BASE_URL, TOKEN, mockDeps)
-        mockBrowserInstance.newPage.mockClear()
-
-        mockBrowserInstance.newPage.mockImplementation(async () =>
-          makePageWithGotoTrigger(
-            'Received event for unknown subscription 99. Unsubscribing.',
-          ),
-        )
-
-        await browser.navigatePage({
-          pagePath: '/lovelace/0',
-          viewport: DEFAULT_VIEWPORT,
-        })
-
-        expect(browser.busy).toBe(false)
-      })
+      mockBrowserInstance.newPage.mockImplementation(async () =>
+        createMockPage(),
+      )
     })
   })
 


### PR DESCRIPTION
Screenshots could come back blank or missing cards, and setting a wait didn't help.

- the readiness check only looked for loading indicators, so it passed on states that have no indicator and no content: after the launch screen goes but before a panel mounts, and while a mounted panel is still building its cards
- energy cards show a translated "Loading" string as plain text with no element or class, so nothing detected them
- the retry for the WebSocket subscription race routed to "/" and back, which lands on the default dashboard instead of unmounting, and left cards rebuilding when the screenshot was taken
- setting a wait skipped the readiness checks entirely
- charts grow their bars from zero as data arrives, so captures caught them empty

Changes:

- readiness now also requires a mounted panel reporting itself loaded, every card a view has declared, and energy cards holding their data
- removed the subscription race retry
- a wait now adds to the readiness checks rather than replacing them, so it can lengthen a capture but never shorten the checks
- pages render with reduced motion so charts are captured at their final state
- a warning is raised once if a future Home Assistant stops exposing the fields these checks rely on
- removed the 50KB size warning from the preview, the upload endpoint validates that

Attempts #84, and #87.