### PR TITLE
Fixed the release script assuming a single add-on

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,12 +4,23 @@
 
 Automates the version bump process across all project files.
 
-### What it does
+`--addon` is required. The repo ships two add-ons off one tag stream, and
+releasing the wrong one is silent, so there is no default.
+
+### trmnl-ha
+
+Versioned in this repo and tagged `v<version>`.
 
 1. Bumps version in `package.json`, `config.yaml`, and `CHANGELOG.md`
 2. Creates a git commit with the changes
 3. Tags the commit with the new version
 4. Optionally pushes to remote
+
+### trmnl-terminus
+
+Its version mirrors the bundled Terminus release and is written by the
+`terminus-upstream-bump` workflow, so it takes no bump type. The script only
+publishes whatever `config.yaml` already says, tagged `terminus-v<version>`.
 
 ### Usage
 
@@ -24,9 +35,12 @@ npm run release:major     # 0.0.1 -> 1.0.0
 npm run release:dry       # See what would change
 
 # Direct script usage
-bun scripts/release.js patch
-bun scripts/release.js minor --dry-run
-bun scripts/release.js major --push
+bun scripts/release.js --addon=trmnl-ha patch
+bun scripts/release.js --addon=trmnl-ha minor --dry-run
+bun scripts/release.js --addon=trmnl-ha major --push
+
+# Publish the Terminus add-on at its current version
+bun scripts/release.js --addon=trmnl-terminus --push
 ```
 
 ### Options

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -15,11 +15,37 @@ const __dirname = dirname(__filename)
 const ROOT_DIR = join(__dirname, '..')
 const GITHUB_REPO = 'usetrmnl/trmnl-home-assistant'
 
-// File paths
-const PATHS = {
-  packageJson: join(ROOT_DIR, 'trmnl-ha/ha-trmnl/package.json'),
-  configYaml: join(ROOT_DIR, 'trmnl-ha/config.yaml'),
-  changelog: join(ROOT_DIR, 'trmnl-ha/CHANGELOG.md'),
+// The repo ships two add-ons off one tag stream, so which one is being released
+// has to be stated rather than assumed.
+const ADDONS = {
+  'trmnl-ha': {
+    dir: 'trmnl-ha',
+    packageJson: 'trmnl-ha/ha-trmnl/package.json',
+    tagPrefix: 'v',
+    bumpable: true,
+  },
+  'trmnl-terminus': {
+    dir: 'trmnl-terminus',
+    packageJson: null,
+    tagPrefix: 'terminus-v',
+    // Its version mirrors the bundled Terminus release, so it is never bumped
+    // here - the upstream bump workflow sets it and this only publishes it.
+    bumpable: false,
+  },
+}
+
+let ADDON
+let PATHS
+let TAG_PREFIX
+
+function selectAddon(slug) {
+  ADDON = ADDONS[slug]
+  TAG_PREFIX = ADDON.tagPrefix
+  PATHS = {
+    packageJson: ADDON.packageJson ? join(ROOT_DIR, ADDON.packageJson) : null,
+    configYaml: join(ROOT_DIR, ADDON.dir, 'config.yaml'),
+    changelog: join(ROOT_DIR, ADDON.dir, 'CHANGELOG.md'),
+  }
 }
 
 /**
@@ -41,17 +67,24 @@ function bumpVersion(version, type) {
 }
 
 /**
- * Get current version from package.json
+ * Get current version from package.json, or config.yaml for add-ons without one
  */
 function getCurrentVersion() {
-  const pkg = JSON.parse(readFileSync(PATHS.packageJson, 'utf8'))
-  return pkg.version
+  if (PATHS.packageJson) {
+    return JSON.parse(readFileSync(PATHS.packageJson, 'utf8')).version
+  }
+  const match = readFileSync(PATHS.configYaml, 'utf8').match(
+    /^version: "(.*)"$/m
+  )
+  if (!match) throw new Error(`No version found in ${PATHS.configYaml}`)
+  return match[1]
 }
 
 /**
  * Update package.json version
  */
 function updatePackageJson(newVersion) {
+  if (!PATHS.packageJson) return
   const pkg = JSON.parse(readFileSync(PATHS.packageJson, 'utf8'))
   pkg.version = newVersion
   writeFileSync(PATHS.packageJson, JSON.stringify(pkg, null, 2) + '\n')
@@ -74,11 +107,15 @@ function updateConfigYaml(newVersion) {
 function getCommitsSinceLastTag() {
   let lastTag
   try {
-    // Use git tag with sort to get most recent tag reliably
-    lastTag = execSync('git tag -l --sort=-creatordate | head -1', {
-      encoding: 'utf8',
-      shell: true,
-    }).trim()
+    // Scoped to this add-on's prefix: the other add-on's tags interleave in this
+    // repo, and an unfiltered lookup builds the changelog from the wrong range.
+    lastTag = execSync(
+      `git tag -l '${TAG_PREFIX}*' --sort=-creatordate | head -1`,
+      {
+        encoding: 'utf8',
+        shell: true,
+      }
+    ).trim()
   } catch {
     // No tags yet
     lastTag = ''
@@ -211,7 +248,7 @@ function updateChangelog(newVersion, previousVersion, entries) {
   const rest = content.slice(headerEnd)
 
   // Update comparison links at the bottom
-  const newLink = `[${newVersion}]: https://github.com/${GITHUB_REPO}/compare/v${previousVersion}...v${newVersion}`
+  const newLink = `[${newVersion}]: https://github.com/${GITHUB_REPO}/compare/${TAG_PREFIX}${previousVersion}...${TAG_PREFIX}${newVersion}`
 
   // Find where links section starts (after ---)
   const linksStart = rest.lastIndexOf('\n[')
@@ -242,11 +279,19 @@ function getCurrentBranch() {
  * Create git commit and tag
  */
 function gitCommitAndTag(version, dryRun = false) {
-  const commands = [
-    `git add ${PATHS.packageJson} ${PATHS.configYaml} ${PATHS.changelog}`,
-    `git commit -m "Release ${version}"`,
-    `git tag -a v${version} -m "Release ${version}"`,
-  ]
+  const tag = `${TAG_PREFIX}${version}`
+  const staged = [PATHS.packageJson, PATHS.configYaml, PATHS.changelog]
+    .filter(Boolean)
+    .join(' ')
+
+  // Nothing to bump for a mirrored version, so the release is the tag alone.
+  const commands = ADDON.bumpable
+    ? [
+        `git add ${staged}`,
+        `git commit -m "Release ${version}"`,
+        `git tag -a ${tag} -m "Release ${version}"`,
+      ]
+    : [`git tag -a ${tag} -m "Release ${version}"`]
 
   if (dryRun) {
     console.log('\n🔍 Dry run - would execute:')
@@ -263,7 +308,7 @@ function gitCommitAndTag(version, dryRun = false) {
     }
   })
 
-  console.log(`✅ Created git commit and tag v${version}`)
+  console.log(`✅ Created git tag ${TAG_PREFIX}${version}`)
 }
 
 /**
@@ -272,11 +317,17 @@ function gitCommitAndTag(version, dryRun = false) {
 function release(bumpType, options = {}) {
   const { dryRun = false, push = false } = options
 
-  console.log(`\n🚀 Starting release process (${bumpType})\n`)
+  console.log(
+    `\n🚀 Starting release process (${ADDON.dir}${
+      bumpType ? `, ${bumpType}` : ''
+    })\n`
+  )
 
   // Get current and new version
   const currentVersion = getCurrentVersion()
-  const newVersion = bumpVersion(currentVersion, bumpType)
+  const newVersion = ADDON.bumpable
+    ? bumpVersion(currentVersion, bumpType)
+    : currentVersion
 
   console.log(`📦 Current version: ${currentVersion}`)
   console.log(`📦 New version: ${newVersion}\n`)
@@ -348,10 +399,14 @@ function release(bumpType, options = {}) {
     process.exit(1)
   }
 
-  // Update all files
-  updatePackageJson(newVersion)
-  updateConfigYaml(newVersion)
-  updateChangelog(newVersion, currentVersion, entries)
+  // A mirrored version is already written by the upstream bump workflow.
+  if (ADDON.bumpable) {
+    updatePackageJson(newVersion)
+    updateConfigYaml(newVersion)
+    updateChangelog(newVersion, currentVersion, entries)
+  } else {
+    console.log(`📦 Publishing ${ADDON.dir} at its current version\n`)
+  }
 
   // Git commit and tag
   gitCommitAndTag(newVersion)
@@ -359,7 +414,9 @@ function release(bumpType, options = {}) {
   if (push) {
     console.log('\n📤 Pushing to remote...')
     // Push commit and ONLY the new tag (not all tags)
-    execSync(`git push && git push origin v${newVersion}`, { stdio: 'inherit' })
+    execSync(`git push && git push origin ${TAG_PREFIX}${newVersion}`, {
+      stdio: 'inherit',
+    })
     console.log('✅ Pushed commit and tag to remote')
 
     // Create GitHub release with changelog notes (using pre-captured entries)
@@ -368,7 +425,7 @@ function release(bumpType, options = {}) {
 
     try {
       execSync(
-        `gh release create v${newVersion} --title "v${newVersion}" -R ${GITHUB_REPO} --notes "${releaseNotes.replace(
+        `gh release create ${TAG_PREFIX}${newVersion} --title "${TAG_PREFIX}${newVersion}" -R ${GITHUB_REPO} --notes "${releaseNotes.replace(
           /"/g,
           '\\"'
         )}"`,
@@ -384,13 +441,13 @@ function release(bumpType, options = {}) {
         '⚠️  Failed to create GitHub release. Create manually with:'
       )
       console.log(
-        `   gh release create v${newVersion} --title "v${newVersion}" -R ${GITHUB_REPO}`
+        `   gh release create ${TAG_PREFIX}${newVersion} --title "${TAG_PREFIX}${newVersion}" -R ${GITHUB_REPO}`
       )
     }
   } else {
-    console.log(`\n💡 To push: git push && git push origin v${newVersion}`)
+    console.log(`\n💡 To push: git push && git push origin ${TAG_PREFIX}${newVersion}`)
     console.log(
-      `💡 Then create release: gh release create v${newVersion} -R ${GITHUB_REPO}`
+      `💡 Then create release: gh release create ${TAG_PREFIX}${newVersion} -R ${GITHUB_REPO}`
     )
   }
 
@@ -399,17 +456,24 @@ function release(bumpType, options = {}) {
 
 // Parse CLI arguments
 const args = process.argv.slice(2)
-const bumpType = args[0]
+const addonArg = args.find((a) => a.startsWith('--addon='))?.split('=')[1]
+const bumpType = args.find((a) => ['patch', 'minor', 'major'].includes(a))
 const flags = {
   dryRun: args.includes('--dry-run') || args.includes('-d'),
   push: args.includes('--push') || args.includes('-p'),
 }
 
-if (!bumpType || !['patch', 'minor', 'major'].includes(bumpType)) {
-  console.error(`
-Usage: bun scripts/release.js [patch|minor|major] [options]
+const usage = `
+Usage: bun scripts/release.js --addon=<name> [patch|minor|major] [options]
 
-Bump types:
+Add-ons:
+  trmnl-ha         versioned here; takes a bump type, tags v<version>
+  trmnl-terminus   version mirrors the bundled Terminus and is set by the
+                   upstream bump workflow, so it takes no bump type and
+                   publishes whatever config.yaml already says as
+                   terminus-v<version>
+
+Bump types (trmnl-ha only):
   patch   0.0.1 -> 0.0.2 (bug fixes)
   minor   0.0.1 -> 0.1.0 (new features, backwards compatible)
   major   0.0.1 -> 1.0.0 (breaking changes)
@@ -419,10 +483,31 @@ Options:
   --push, -p       Push commit and tags to remote after release
 
 Examples:
-  bun scripts/release.js patch
-  bun scripts/release.js minor --dry-run
-  bun scripts/release.js major --push
-`)
+  bun scripts/release.js --addon=trmnl-ha patch
+  bun scripts/release.js --addon=trmnl-ha minor --dry-run
+  bun scripts/release.js --addon=trmnl-terminus --push
+`
+
+// Required rather than defaulted: releasing the wrong add-on is silent, and
+// both live in one repo off one tag stream.
+if (!addonArg || !ADDONS[addonArg]) {
+  console.error(
+    `\n❌ Pass --addon=<${Object.keys(ADDONS).join('|')}>\n${usage}`
+  )
+  process.exit(1)
+}
+
+selectAddon(addonArg)
+
+if (ADDON.bumpable && !bumpType) {
+  console.error(`\n❌ ${addonArg} needs a bump type\n${usage}`)
+  process.exit(1)
+}
+
+if (!ADDON.bumpable && bumpType) {
+  console.error(
+    `\n❌ ${addonArg} takes no bump type - its version mirrors the bundled Terminus release\n${usage}`
+  )
   process.exit(1)
 }
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -6,7 +6,7 @@
  */
 
 import { readFileSync, writeFileSync } from 'fs'
-import { execSync } from 'child_process'
+import { execSync, execFileSync } from 'child_process'
 import { fileURLToPath } from 'url'
 import { dirname, join } from 'path'
 
@@ -424,11 +424,21 @@ function release(bumpType, options = {}) {
     const releaseNotes = entries || `Release ${newVersion}`
 
     try {
-      execSync(
-        `gh release create ${TAG_PREFIX}${newVersion} --title "${TAG_PREFIX}${newVersion}" -R ${GITHUB_REPO} --notes "${releaseNotes.replace(
-          /"/g,
-          '\\"'
-        )}"`,
+      // NOTE: argv form, not a shell string - release notes are built from commit
+      // subjects, which would otherwise be evaluated as shell syntax.
+      execFileSync(
+        'gh',
+        [
+          'release',
+          'create',
+          `${TAG_PREFIX}${newVersion}`,
+          '--title',
+          `${TAG_PREFIX}${newVersion}`,
+          '-R',
+          GITHUB_REPO,
+          '--notes',
+          releaseNotes,
+        ],
         {
           stdio: 'inherit',
         }

--- a/trmnl-ha/ha-trmnl/package.json
+++ b/trmnl-ha/ha-trmnl/package.json
@@ -26,10 +26,10 @@
     "typecheck": "tsc --noEmit",
     "typecheck:watch": "tsc --noEmit --watch",
     "logs:clear": "rm -rf logs/*.log && mkdir -p logs",
-    "release:patch": "bun ../../scripts/release.js patch",
-    "release:minor": "bun ../../scripts/release.js minor",
-    "release:major": "bun ../../scripts/release.js major",
-    "release:dry": "bun ../../scripts/release.js patch --dry-run"
+    "release:patch": "bun ../../scripts/release.js --addon=trmnl-ha patch",
+    "release:minor": "bun ../../scripts/release.js --addon=trmnl-ha minor",
+    "release:major": "bun ../../scripts/release.js --addon=trmnl-ha major",
+    "release:dry": "bun ../../scripts/release.js --addon=trmnl-ha patch --dry-run"
   },
   "dependencies": {
     "@logtape/logtape": "^1.3.5",


### PR DESCRIPTION
`scripts/release.js` was written when the repo had one add-on. Pointed at Terminus it would have bumped trmnl-ha's `config.yaml` and tagged `v<version>`, which `release.yml` routes to trmnl-ha — publishing the wrong add-on with no visible sign anything was off.

Adding the Terminus tag stream also broke changelog generation: `git tag -l --sort=-creatordate | head -1` now returns `terminus-v0.66.0`, so a trmnl-ha release would have generated notes from the wrong range.

- requires `--addon=<trmnl-ha|trmnl-terminus>`; no default, because the failure is silent
- scopes the last-tag lookup to the add-on's own prefix
- takes the version from `config.yaml` when an add-on has no `package.json`
- Terminus takes no bump type: its version mirrors the bundled release, so it tags and publishes what `config.yaml` already says
- npm `release:*` scripts updated so they keep working

Verified by dry run: trmnl-ha reports 0.9.4 -> 0.9.5 with 13 commits since `v0.9.4` (not the 1 since `terminus-v0.66.0`) and tags `v0.9.5`; Terminus reports 0.66.0 and tags `terminus-v0.66.0` with no commit. All four refusal paths reject.