### PR TITLE
Wait for the websocket to go quiet before capturing

### DIFF
--- a/trmnl-ha/CHANGELOG.md
+++ b/trmnl-ha/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Energy and history cards were captured before their data arrived, showing "Loading" or empty axes. Navigation now waits for the Home Assistant websocket to go quiet, and restores waiting for the network to settle, before capturing (#87, #84)
+
 ## [0.9.4] - 2026-08-02
 
 ### Added

--- a/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
+++ b/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
@@ -84,12 +84,10 @@ export class NavigateToPage {
 
     let response
     try {
-      // 'load' is enough here: the wait pipeline that follows (hass
-      // readiness, loading indicators, paint stability) detects actual
-      // readiness, and a network-idle wait would add a fixed 500ms idle
-      // window on top of it.
+      // networkidle2, not the faster 'load': cards keep loading resources
+      // after the load event fires, so 'load' captures a half-drawn dashboard.
       response = await this.#page.goto(pageUrl, {
-        waitUntil: 'load',
+        waitUntil: 'networkidle2',
         timeout: NAVIGATION_TIMEOUT,
       })
     } catch (err) {
@@ -445,6 +443,62 @@ export class WaitForPaintStability {
       )
     } catch (_err) {
       log.debug`Paint stability check timed out`
+    }
+  }
+}
+
+/**
+ * Waits for the Home Assistant websocket to go quiet.
+ *
+ * Energy and history cards render a plain "Loading" string with no element to
+ * match on while they fetch their data over the websocket, which an HTTP
+ * network-idle check cannot see. Watching the frames covers every such card
+ * without depending on card internals.
+ *
+ * `quietMs` must be long enough to span a card's fetch but short enough to fit
+ * between the routine state updates that also travel this websocket. `timeout`
+ * caps the wait for a dashboard whose updates never pause.
+ */
+export class WaitForWebSocketIdle {
+  #page: Page
+  #quietMs: number
+  #timeout: number
+
+  constructor(page: Page, quietMs: number = 500, timeout: number = 12000) {
+    this.#page = page
+    this.#quietMs = quietMs
+    this.#timeout = timeout
+  }
+
+  async call(): Promise<void> {
+    let client
+    try {
+      client = await this.#page.createCDPSession()
+      await client.send('Network.enable')
+
+      let lastFrameAt = Date.now()
+      const recordFrame = (): void => {
+        lastFrameAt = Date.now()
+      }
+      client.on('Network.webSocketFrameReceived', recordFrame)
+      client.on('Network.webSocketFrameSent', recordFrame)
+
+      const start = Date.now()
+      while (Date.now() - start < this.#timeout) {
+        if (Date.now() - lastFrameAt >= this.#quietMs) return
+        await new Promise((resolve) => setTimeout(resolve, 100))
+      }
+      log.debug`Websocket idle wait reached its ${this.#timeout}ms limit`
+    } catch (err) {
+      log.debug`Websocket idle wait skipped: ${(err as Error).message}`
+    } finally {
+      if (client) {
+        try {
+          await client.detach()
+        } catch (_err) {
+          /* session already gone */
+        }
+      }
     }
   }
 }

--- a/trmnl-ha/ha-trmnl/screenshot.ts
+++ b/trmnl-ha/ha-trmnl/screenshot.ts
@@ -37,6 +37,7 @@ import {
   WaitForLoadingComplete,
   DismissToasts,
   WaitForPaintStability,
+  WaitForWebSocketIdle,
   WaitForHassReady,
   type AuthStorage,
 } from './lib/browser/navigation-commands.js'
@@ -503,7 +504,7 @@ export class Browser {
 
       // An explicit wait adds to these stages rather than replacing them, so
       // it can lengthen a capture but never shorten the checks.
-      // NOTE: page.goto() already uses waitUntil:'networkidle2' so network is settled
+      // page.goto() already waits for networkidle2, so the network is settled.
 
       // Stage 1: Wait for network to re-settle after theme/language changes
       // Theme and language changes trigger WebSocket messages and cascading renders
@@ -538,7 +539,14 @@ export class Browser {
         if (count > 0) log.debug`Dismissed ${count} notification toast(s)`
       }
 
-      // Stage 5: Wait for rendering pipeline to flush
+      // Stage 5: Wait for the websocket to go quiet, so cards that fetch
+      // their data over it (energy, history) have it before capture.
+      if (!isGenericUrl) {
+        const wsIdleCmd = new WaitForWebSocketIdle(page)
+        await timed('nav.waitWsIdle', () => wsIdleCmd.call())
+      }
+
+      // Stage 6: Wait for rendering pipeline to flush
       const paintCmd = new WaitForPaintStability(page)
       await timed('nav.waitPaint', () => paintCmd.call())
 

--- a/trmnl-ha/ha-trmnl/tests/unit/navigation-commands.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/navigation-commands.test.ts
@@ -13,6 +13,7 @@ import {
   WaitForLoadingComplete,
   DismissToasts,
   WaitForPaintStability,
+  WaitForWebSocketIdle,
   WaitForHassReady,
   UpdateLanguage,
   UpdateTheme,
@@ -275,7 +276,7 @@ describe('NavigateToPage', () => {
       expect(opts.timeout).toBe(NAVIGATION_TIMEOUT)
     })
 
-    it('waits only for the load event, not network idle', async () => {
+    it('waits for the network to settle so card resources finish loading', async () => {
       const mockPage = createMockPage()
       const nav = new NavigateToPage(
         mockPage,
@@ -286,7 +287,7 @@ describe('NavigateToPage', () => {
       await nav.call('/lovelace/0')
 
       const opts = mockPage.calls.gotoOptions[0] as { waitUntil?: string }
-      expect(opts.waitUntil).toBe('load')
+      expect(opts.waitUntil).toBe('networkidle2')
     })
   })
 
@@ -707,6 +708,88 @@ describe('WaitForPaintStability', () => {
     await cmd.call()
 
     expect(typeof capturedFn).toBe('function')
+  })
+})
+
+// =============================================================================
+// WaitForWebSocketIdle
+// =============================================================================
+
+/** A CDP session whose websocket frame events a test can drive. */
+function createWebSocketMockPage(options: { cdpUnavailable?: boolean } = {}): {
+  page: Page
+  emitFrame: () => void
+  wasDetached: () => boolean
+} {
+  const handlers: (() => void)[] = []
+  let detached = false
+
+  const page = {
+    createCDPSession: async () => {
+      if (options.cdpUnavailable) throw new Error('CDP unavailable')
+      return {
+        send: async () => {},
+        on: (_event: string, handler: () => void) => handlers.push(handler),
+        detach: async () => {
+          detached = true
+        },
+      }
+    },
+  } as unknown as Page
+
+  return {
+    page,
+    emitFrame: () => handlers.forEach((handler) => handler()),
+    wasDetached: () => detached,
+  }
+}
+
+describe('WaitForWebSocketIdle', () => {
+  it('resolves once no frame has arrived for the quiet window', async () => {
+    const { page } = createWebSocketMockPage()
+    const start = Date.now()
+
+    await new WaitForWebSocketIdle(page, 150, 2000).call()
+
+    expect(Date.now() - start).toBeGreaterThanOrEqual(150)
+  })
+
+  it('waits while frames keep arriving, then resolves after they stop', async () => {
+    const { page, emitFrame } = createWebSocketMockPage()
+    const interval = setInterval(emitFrame, 50)
+    setTimeout(() => clearInterval(interval), 250)
+    const start = Date.now()
+
+    await new WaitForWebSocketIdle(page, 150, 2000).call()
+
+    expect(Date.now() - start).toBeGreaterThanOrEqual(400)
+  })
+
+  it('stops at the timeout when frames never stop', async () => {
+    const { page, emitFrame } = createWebSocketMockPage()
+    const interval = setInterval(emitFrame, 40)
+    const start = Date.now()
+
+    await new WaitForWebSocketIdle(page, 300, 250).call()
+
+    clearInterval(interval)
+    const elapsed = Date.now() - start
+    expect(elapsed).toBeGreaterThanOrEqual(250)
+    expect(elapsed).toBeLessThan(700)
+  })
+
+  it('detaches the CDP session when done', async () => {
+    const { page, wasDetached } = createWebSocketMockPage()
+
+    await new WaitForWebSocketIdle(page, 100, 2000).call()
+
+    expect(wasDetached()).toBe(true)
+  })
+
+  it('does not throw when a CDP session cannot be created', async () => {
+    const { page } = createWebSocketMockPage({ cdpUnavailable: true })
+
+    await new WaitForWebSocketIdle(page, 100, 2000).call()
   })
 })
 


### PR DESCRIPTION
Energy and history cards fetch their data over the Home Assistant websocket and show a plain Loading string until it arrives. No HTTP network-idle check can see that traffic, so dashboards were captured mid-load (#87, #84).

- Adds a wait that watches the websocket frames and captures once they stop
- Restores networkidle2 on navigation so card resources finish loading
- Covers the new wait with tests

Reproduced locally with a custom card that fetches over the websocket and shows Loading until it responds: on this branch the card is captured filled in, on 0.9.4 it is captured showing Loading.