### PR TITLE
Updated Terminus to 0.69.0

### DIFF
--- a/trmnl-terminus/CHANGELOG.md
+++ b/trmnl-terminus/CHANGELOG.md
@@ -7,6 +7,12 @@ The version mirrors the [Terminus](https://github.com/usetrmnl/terminus) release
 the add-on bundles, so add-on 0.66.0 ships Terminus 0.66.0. A wrapper-only fix
 between upstream releases takes a `-1`, `-2` suffix.
 
+## [0.69.0] - 2026-08-17
+
+### Changed
+
+- Updated Terminus to 0.69.0
+
 ## [0.68.0] - 2026-08-10
 
 ### Changed

--- a/trmnl-terminus/build.yaml
+++ b/trmnl-terminus/build.yaml
@@ -1,4 +1,4 @@
 ---
 build_from:
-  aarch64: ghcr.io/usetrmnl/terminus:0.68.0
-  amd64: ghcr.io/usetrmnl/terminus:0.68.0
+  aarch64: ghcr.io/usetrmnl/terminus:0.69.0
+  amd64: ghcr.io/usetrmnl/terminus:0.69.0

--- a/trmnl-terminus/config.yaml
+++ b/trmnl-terminus/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Terminus Server (BYOS)
-version: "0.68.0"
+version: "0.69.0"
 slug: trmnl-terminus
 description: >-
   Starts a Terminus Server that enables local management of TRMNL devices (BYOS)


### PR DESCRIPTION
Upstream tagged `0.69.0`; the add-on pinned `0.68.0`.

- bumps the base image in `build.yaml` for both architectures
- bumps `config.yaml` to `0.69.0`, which the add-on version mirrors
- adds a CHANGELOG entry

Upstream changes: https://github.com/usetrmnl/terminus/compare/0.68.0...0.69.0

Publishing needs a `terminus-v0.69.0` release once this merges - the Supervisor pulls `image:version` from `config.yaml`, so merging alone ships nothing.
