### PR TITLE
Added a test for the add-on option passthrough

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,12 @@ jobs:
           cache-to: ${{ github.event_name == 'push' && format('type=registry,ref={0}/{1}:{2},mode=max', env.REGISTRY, env.TERMINUS_CACHE_REPO, matrix.tag) || format('type=gha,mode=max,scope=terminus-{0}', matrix.tag) }}
           provenance: false
 
+      # The boot test below starts the add-on with ha_ip alone, so nothing
+      # there exercises an option. This does.
+      - name: Test add-on option handling
+        if: matrix.tag == 'amd64'
+        run: trmnl-terminus/tests/init-environment.test.sh trmnl-terminus:test-amd64
+
       # amd64 only - QEMU makes arm64 boot tests too slow here.
       - name: Smoke test add-on boot
         if: matrix.tag == 'amd64'

--- a/trmnl-terminus/tests/init-environment.test.sh
+++ b/trmnl-terminus/tests/init-environment.test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Checks what the add-on's options turn into for the Terminus processes.
+#
+# Every case asserts on the environment a service actually sees: it runs the
+# real init script in the built image, then sources terminus-env.sh the way
+# the puma and sidekiq run scripts do. That covers the whole chain rather than
+# the shape of the file in the middle of it.
+#
+# Usage: trmnl-terminus/tests/init-environment.test.sh [image]
+set -uo pipefail
+
+IMAGE="${1:-trmnl-terminus:dev}"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+FAILED=0
+
+# Prints one variable as the services would see it, or UNSET when the options
+# left it alone and Terminus is to apply its own default.
+resolve() {
+    printf '%s' "$1" > "$WORK/options.json"
+    # s6 puts /command on PATH and creates the container environment directory
+    # at stage 2; the script's with-contenv shebang needs both to run.
+    docker run --rm --entrypoint bash \
+        -e PATH=/command:/usr/local/bin:/usr/bin:/bin \
+        -e VAR="$2" \
+        -v "$WORK/options.json:/data/options.json:ro" \
+        "$IMAGE" -c 'set -e
+            mkdir -p /run/s6/container_environment
+            /etc/cont-init.d/01-init-environment.sh >/dev/null
+            source /usr/local/bin/terminus-env.sh
+            printf "%s" "${!VAR-UNSET}"'
+}
+
+assert_resolves() {
+    local name="$1" options="$2" variable="$3" expected="$4" actual
+    actual=$(resolve "$options" "$variable")
+    if [ "$actual" = "$expected" ]; then
+        echo "ok   - $name"
+    else
+        echo "FAIL - $name"
+        echo "       $variable expected: [$expected]"
+        echo "       $variable actual:   [$actual]"
+        FAILED=1
+    fi
+}
+
+BASE='"ha_ip":"192.168.1.50"'
+
+assert_resolves "an option left unset keeps Terminus' own default" \
+    "{$BASE}" API_ACCESS_TOKEN_PERIOD UNSET
+
+assert_resolves "a set option reaches the services" \
+    "{$BASE,\"api_access_token_period\":3600}" API_ACCESS_TOKEN_PERIOD 3600
+
+# jq's // falls through on false as well as null, so a boolean turned off has
+# to survive as "false" rather than read as "not set".
+assert_resolves "an option turned off survives as false" \
+    "{$BASE,\"session_expiration_enabled\":false}" SESSION_EXPIRATION_ENABLED false
+
+# Options are not a way to rewire the container: the vars the add-on manages
+# are absent from PASSTHROUGH_OPTIONS, so naming one changes nothing.
+assert_resolves "add-on config cannot rewrite the API URI" \
+    "{$BASE,\"api_uri\":\"http://elsewhere\"}" API_URI http://192.168.1.50:2300
+
+assert_resolves "add-on config cannot rewrite the database" \
+    "{$BASE,\"database_url\":\"postgres://elsewhere\"}" \
+    DATABASE_URL postgres://postgres@localhost/terminus
+
+# Written with printf %q and read back by the shell, so anything needing
+# quotes has to survive the round trip intact.
+assert_resolves "a value containing spaces arrives whole" \
+    "{$BASE,\"rack_attack_allowed_subnets\":\"10.0.0.0/8, 192.168.0.0/16\"}" \
+    RACK_ATTACK_ALLOWED_SUBNETS "10.0.0.0/8, 192.168.0.0/16"
+
+exit "$FAILED"


### PR DESCRIPTION
Nothing in CI exercises an add-on option today: the boot test starts the container with `ha_ip` alone, so the passthrough loop added in #97 runs with an empty list every time.

This adds six cases that run the real init script in the built image, then source `terminus-env.sh` the way the puma and sidekiq run scripts do, so each one asserts on the environment a service actually sees rather than the shape of the file in between.

What they cover:

- an option left unset exports nothing, so Terminus applies its own default
- a set option reaches the services
- an option turned off arrives as `false` rather than reading as unset, which is why the value is read with `jq`'s `select` rather than `//`
- `api_uri` and `database_url` named in add-on config change nothing, because the variables the add-on manages are absent from `PASSTHROUGH_OPTIONS` — the passthrough file is sourced after those variables are set, so curation of that list is the only thing protecting them
- a value containing spaces survives the `printf %q` round trip intact

I checked the cases bite rather than just pass: swapping `select(. != null)` for `// empty`, and adding `api_uri` to `PASSTHROUGH_OPTIONS`, each fails exactly one case and leaves the other four green.

Runs on amd64 only, matching the existing boot test, and adds about ten seconds.