### PR TITLE
Updated sessions to no longer expire by default

### DIFF
--- a/trmnl-terminus/CHANGELOG.md
+++ b/trmnl-terminus/CHANGELOG.md
@@ -19,6 +19,9 @@ between upstream releases takes a `-1`, `-2` suffix.
 
 ### Changed
 
+- Sessions no longer expire by default. Terminus ends a session 24 hours after
+  login however often its token is refreshed, which broke scheduled pushes
+  overnight until someone signed in again
 - Updated Terminus to 0.69.0
 
 ## [0.68.0] - 2026-08-10

--- a/trmnl-terminus/DOCS.md
+++ b/trmnl-terminus/DOCS.md
@@ -12,7 +12,7 @@ The IP address of your Home Assistant instance (e.g. `192.168.1.50`).
 
 ### Terminus settings (optional)
 
-Every other option is optional and left unset by default, in which case Terminus applies its own default. Setting one exports the matching [Terminus environment variable](https://github.com/usetrmnl/terminus/blob/main/doc/configuration.adoc) (the option key, uppercased) into the server and worker processes.
+Every other option is optional. Apart from **Session expiration**, described below, each is left unset by default, in which case Terminus applies its own default. Setting one exports the matching [Terminus environment variable](https://github.com/usetrmnl/terminus/blob/main/doc/configuration.adoc) (the option key, uppercased) into the server and worker processes.
 
 | Option | Environment variable | Terminus default |
 |--------|----------------------|------------------|
@@ -38,6 +38,14 @@ Every other option is optional and left unset by default, in which case Terminus
 Variables the add-on manages itself — `API_URI`, `APP_SECRET`, `APP_SETUP`, `DATABASE_*`, `KEYVALUE_*`, `HANAMI_PORT`, `FONTS_PATH` — are not configurable, since the container wires them to its bundled Postgres, Valkey and `/data` layout.
 
 To add another variable from the Terminus docs, add the lowercased key to `schema:` in `config.yaml` and to `PASSTHROUGH_OPTIONS` in `rootfs/etc/cont-init.d/01-init-environment.sh`.
+
+### Session expiration (default: off)
+
+This is the one option the add-on sets a default for. Terminus expires a session after 30 minutes idle and 24 hours in total, and ties its API tokens to that session. Anything pushing screens on a schedule cannot survive those limits unattended: refreshing resets the inactivity timer but never the lifetime cap, so the session lapses a day after login however diligently the token is refreshed, and every push then fails until somebody signs in by hand. Sessions therefore do not expire unless you switch this on.
+
+Turn it on if the server is reachable beyond your trusted network, and expect to re-authenticate any BYOS push schedules once per lifetime. The [TRMNL add-on](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/docs/webhook-formats.md) can save its login and sign in again on its own if you would rather keep expiry on.
+
+Raising `api_access_token_period` on its own does not extend a session: `session_inactivity_limit` and `session_lifetime_limit` still apply, and the shortest of the three is what ends it. Move all three together.
 
 ## Security
 

--- a/trmnl-terminus/config.yaml
+++ b/trmnl-terminus/config.yaml
@@ -27,6 +27,12 @@ backup: cold
 backup_exclude:
   - "*/logs/*"
   - "*/tmp/*"
+options:
+  # Terminus expires a session 24 hours after login however often its token is
+  # refreshed, which a scheduled push cannot survive unattended. Its own
+  # default suits a server on the open internet; this one suits the trusted
+  # network the add-on is built for.
+  session_expiration_enabled: false
 schema:
   ha_ip: str
   # Optional Terminus tunables. Each key maps to the env var of the same name,

--- a/trmnl-terminus/options-dev.json.example
+++ b/trmnl-terminus/options-dev.json.example
@@ -1,4 +1,4 @@
 {
   "ha_ip": "192.168.1.50",
-  "api_access_token_period": 3600
+  "session_expiration_enabled": false
 }

--- a/trmnl-terminus/translations/en.yaml
+++ b/trmnl-terminus/translations/en.yaml
@@ -8,13 +8,15 @@ configuration:
   api_access_token_period:
     name: API access token period
     description: >-
-      Seconds a device API access token stays valid before a refresh is
-      required. Leave empty for the Terminus default (1800).
+      Seconds an API access token stays valid before it has to be refreshed.
+      Only applies while session expiration is on. Leave empty for the
+      Terminus default (1800).
   session_expiration_enabled:
     name: Session expiration
     description: >-
-      Expire sessions and tokens. Leave empty for the Terminus default
-      (enabled).
+      Expire browser sessions and API tokens. Off by default so scheduled
+      pushes keep working without a daily sign-in. Turn it on if this server
+      is reachable beyond your trusted network.
   session_inactivity_limit:
     name: Session inactivity limit
     description: >-


### PR DESCRIPTION
Follows #97, which made the session settings reachable. This changes what they do out of the box.

Terminus ends a session 24 hours after login and ties its API tokens to it. Refreshing resets the inactivity timer but never the lifetime cap, so a schedule pushing screens breaks a day after setup and stays broken until someone signs in by hand — which is what #60 has been about. Its own default is right for a server on the open internet; this one is right for the trusted network this add-on is built for, and expiry is one tick away for anyone who wants it.

Also in here, both from reading that config page carefully:

- `options-dev.json.example` set `api_access_token_period` on its own. That is the first thing people reach for and the one thing that does not work, because `session_inactivity_limit` and `session_lifetime_limit` still end the session underneath it. Swapped for the option that does, and DOCS now says the three move together.
- The description for `api_access_token_period` called it a device API access token. Devices authenticate against the display endpoint with their own credential; this one is the account JWT.

Checked against a real Terminus 0.69.0. Booting with the options a fresh install would get:

```
[terminus]   SESSION_EXPIRATION_ENABLED=false
fresh install JWT lifetime: 3155760000s = 100.1 years
```

And the measurement behind the 24 hour claim, taken with all three limits set to 60 seconds and a refresh every 35:

```
t=0s   refresh OK
t=35s  refresh OK
t=70s  refresh REJECTED: {"error":"This session has expired, please login again"}
```

Worth a conscious nod before merging: existing installs currently expire sessions and will stop doing so on update.