### PR TITLE
Added an option to stay signed in to a BYOS server

### DIFF
--- a/trmnl-ha/DOCS.md
+++ b/trmnl-ha/DOCS.md
@@ -403,7 +403,7 @@ For BYOS Hanami, the add-on offers two **delivery modes**:
 
 See **[Webhook Formats Guide](docs/webhook-formats.md)** for:
 - Detailed format specifications and delivery mode selection
-- JWT authentication setup for BYOS
+- JWT authentication setup for BYOS, and what to do about sessions that expire
 - Deployment topology examples for the Add-on URL (Docker, LAN, reverse proxy)
 - How to add custom webhook formats
 

--- a/trmnl-ha/docs/webhook-formats.md
+++ b/trmnl-ha/docs/webhook-formats.md
@@ -152,10 +152,19 @@ Schedules created before this feature shipped have no `delivery_mode` field in t
 
 BYOS requires JWT authentication. You can either:
 
-1. **Login via UI:** Enter your BYOS credentials in the schedule settings. The add-on exchanges them for tokens (credentials are NOT stored).
+1. **Login via UI:** Enter your BYOS credentials in the schedule settings. The add-on exchanges them for tokens.
 2. **Manual tokens:** Paste your access and refresh tokens directly if you prefer not to enter credentials.
 
-Tokens auto-refresh when expired (25-minute validity, refreshed before 30-minute expiry).
+The scheduler refreshes tokens every minute once they are 10 minutes old, well inside Terminus' 30 minute access token window.
+
+### Sessions that expire
+
+Terminus ties its API tokens to a login session, and where session expiration is on it ends that session 24 hours after login however often the token is refreshed - refreshing resets the inactivity timer, never the lifetime cap. When it lapses, sends fail with `401` until somebody signs in again.
+
+Two ways to stop that:
+
+- **Stay signed in**, in the schedule's JWT settings. The add-on saves your BYOS login and signs in again by itself when the session lapses. The password is stored in plain text in the add-on's schedules file, alongside the access token that already lives there, so treat the two the same. Leave it off if your server does not expire sessions.
+- **Turn expiry off on the server.** The [Terminus add-on](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-terminus/DOCS.md) does not expire sessions unless you switch **Session expiration** on. Running Terminus yourself with Docker Compose, set `SESSION_EXPIRATION_ENABLED=false` - and note it has to appear in the compose file's `environment:` block, not only in `.env`, or the container never sees it. To keep expiry but make it longer, raise `API_ACCESS_TOKEN_PERIOD`, `SESSION_INACTIVITY_LIMIT` and `SESSION_LIFETIME_LIMIT` together; the shortest of the three is what ends the session.
 
 ### 422 Error Handling
 

--- a/trmnl-ha/ha-trmnl/html/js/app.ts
+++ b/trmnl-ha/ha-trmnl/html/js/app.ts
@@ -954,7 +954,8 @@ class App {
   }
 
   /**
-   * Authenticates with BYOS server. Credentials are NOT stored.
+   * Authenticates with the BYOS server. The login is only stored when the
+   * user asks for it - see ByosAuthConfig.
    */
   async byosLogin(): Promise<void> {
     const schedule = this.#scheduleManager.activeSchedule
@@ -1003,11 +1004,16 @@ class App {
         return
       }
 
-      // Save tokens to schedule (NOT credentials)
+      const remember = (
+        document.getElementById('s_byos_auth_remember') as HTMLInputElement | null
+      )?.checked
+
       const updates = this.#buildByosAuthUpdate(schedule, {
         access_token: result.access_token,
         refresh_token: result.refresh_token,
         obtained_at: result.obtained_at,
+        login_email: remember ? login : undefined,
+        login_password: remember ? password : undefined,
       })
 
       await this.#scheduleManager.update(schedule.id, updates)
@@ -1037,7 +1043,7 @@ class App {
     const confirmed = await this.#confirmModal.show({
       title: 'Logout from BYOS',
       message:
-        'This will remove your authentication tokens. You will need to re-authenticate to send screenshots.',
+        'This will remove your authentication tokens and any saved login. You will need to re-authenticate to send screenshots.',
       confirmText: 'Logout',
       cancelText: 'Cancel',
       confirmClass: 'bg-red-600 hover:bg-red-700',
@@ -1045,11 +1051,13 @@ class App {
 
     if (!confirmed) return
 
-    // Clear auth tokens but keep other BYOS config
+    // Clear auth tokens and any stored login, but keep other BYOS config
     const updates = this.#buildByosAuthUpdate(schedule, {
       access_token: undefined,
       refresh_token: undefined,
       obtained_at: undefined,
+      login_email: undefined,
+      login_password: undefined,
     })
 
     await this.#scheduleManager.update(schedule.id, updates)

--- a/trmnl-ha/ha-trmnl/html/js/ui-renderer.ts
+++ b/trmnl-ha/ha-trmnl/html/js/ui-renderer.ts
@@ -395,14 +395,18 @@ export class RenderScheduleContent {
                   Clear Tokens
                 </button>
               </div>
-              <p class="text-xs text-gray-500 mt-1">Tokens auto-refresh. Valid for ~14 days.</p>
+              <p class="text-xs text-gray-500 mt-1">${
+                byosConfig?.auth?.login_password
+                  ? 'Tokens auto-refresh, and the add-on signs in again on its own if the session expires.'
+                  : 'Tokens auto-refresh. If the server expires the session, sign in again here.'
+              }</p>
               `
                   : `
               <!-- Auth options: Login or Manual Token -->
               <div class="space-y-3">
                 <!-- Option 1: Login with credentials -->
                 <div class="p-2 rounded-md bg-gray-50 border border-gray-200">
-                  <p class="text-xs font-medium text-gray-600 mb-2">Option 1: Login (credentials not stored)</p>
+                  <p class="text-xs font-medium text-gray-600 mb-2">Option 1: Login</p>
                   <div class="space-y-2">
                     <input type="email" id="s_byos_auth_login"
                       class="w-full px-2 py-1 text-sm border rounded-md" style="border-color: var(--primary-light)"
@@ -410,6 +414,11 @@ export class RenderScheduleContent {
                     <input type="password" id="s_byos_auth_password"
                       class="w-full px-2 py-1 text-sm border rounded-md" style="border-color: var(--primary-light)"
                       placeholder="Password" />
+                    <label class="flex items-start gap-2 text-xs text-gray-600 cursor-pointer">
+                      <input type="checkbox" id="s_byos_auth_remember"
+                        class="h-4 w-4 mt-0.5 border-gray-300 rounded" />
+                      <span>Stay signed in &mdash; saves your password so scheduled sends survive the server expiring the session. Leave off unless they keep dropping.</span>
+                    </label>
                     <button type="button" onclick="window.app.byosLogin()"
                       class="w-full px-3 py-1.5 text-sm text-white rounded-md transition hover:opacity-90"
                       style="background-color: var(--primary)">

--- a/trmnl-ha/ha-trmnl/lib/scheduler/byos-auth.ts
+++ b/trmnl-ha/ha-trmnl/lib/scheduler/byos-auth.ts
@@ -33,9 +33,9 @@ const ACCESS_TOKEN_VALIDITY_MS = 10 * 60 * 1000
 
 /**
  * Access token hard expiry on the BYOS server when session expiration is
- * enabled (rodauth's jwt_access_token_period, 1800s). Stock Terminus disables
- * session expiration and issues ~100-year tokens, so this window only matters
- * for hardened installs.
+ * enabled (rodauth's jwt_access_token_period, 1800s). Terminus enables session
+ * expiration by default; the Terminus add-on turns it off, which makes tokens
+ * ~100-year, so this window matters for any install that keeps it on.
  *
  * NOTE: Rodauth rejects refresh requests once the access token has expired,
  * so past this window the only recovery is re-authentication.
@@ -69,6 +69,15 @@ export function isRefreshable(auth: ByosAuthConfig): boolean {
   if (!auth.access_token || !auth.refresh_token || !auth.obtained_at)
     return false
   return Date.now() - auth.obtained_at < ACCESS_TOKEN_EXPIRY_MS
+}
+
+/**
+ * Whether a stored login is available to re-authenticate with. Refreshing
+ * cannot outlive the server's session lifetime cap, so this is the only way
+ * back for a schedule that nobody is watching.
+ */
+export function canRelogin(auth: ByosAuthConfig): boolean {
+  return Boolean(auth.login_email && auth.login_password)
 }
 
 /**
@@ -167,9 +176,44 @@ async function refreshToken(
 }
 
 /**
+ * Re-authenticates with the stored login and adopts the tokens it returns.
+ *
+ * @returns New access token, or null when no login is stored or it failed
+ */
+async function relogin(
+  baseUrl: string,
+  auth: ByosAuthConfig,
+  onTokenRefresh?: (newTokens: TokenResponse) => void,
+): Promise<string | null> {
+  if (!canRelogin(auth)) return null
+
+  try {
+    const tokens = await login(baseUrl, auth.login_email!, auth.login_password!)
+    adoptTokens(auth, tokens, onTokenRefresh)
+    log.info`BYOS auth: re-authenticated with the stored login`
+    return tokens.access_token
+  } catch (err) {
+    log.error`BYOS auth: re-authentication failed: ${(err as Error).message}`
+    return null
+  }
+}
+
+/** Copies fresh tokens into the in-memory auth and persists them. */
+function adoptTokens(
+  auth: ByosAuthConfig,
+  tokens: TokenResponse,
+  onTokenRefresh?: (newTokens: TokenResponse) => void,
+): void {
+  auth.access_token = tokens.access_token
+  auth.refresh_token = tokens.refresh_token
+  auth.obtained_at = Date.now()
+  onTokenRefresh?.(tokens)
+}
+
+/**
  * Gets a valid access token, refreshing if needed. A failed refresh falls
- * back to the stored access token — on stock Terminus it stays valid, and a
- * push with a genuinely expired token fails no worse than one with none.
+ * back to the stored access token — it usually stays valid, and a push with a
+ * genuinely expired token fails no worse than one with none.
  *
  * @param webhookUrl - Full webhook URL (base URL is extracted)
  * @param auth - Stored auth config with tokens
@@ -197,25 +241,25 @@ export async function getValidAccessToken(
     const baseUrl = getBaseUrl(webhookUrl)
     const newTokens = await refreshToken(baseUrl, auth)
 
-    // Update in-memory auth for current execution cycle
-    auth.access_token = newTokens.access_token
-    auth.refresh_token = newTokens.refresh_token
-    auth.obtained_at = Date.now()
-
-    // Persist new tokens to disk for future cron executions
-    if (onTokenRefresh) {
-      onTokenRefresh(newTokens)
-    }
+    adoptTokens(auth, newTokens, onTokenRefresh)
 
     return newTokens.access_token
   } catch (err) {
-    // Rodauth rotates refresh tokens on use, so a concurrent refresh (send
-    // path vs keepalive, each holding its own copy of the auth config) makes
-    // the loser's refresh token invalid → 400. The stored access token is
-    // still valid on the server (stock Terminus tokens live ~100 years, and
-    // even with session expiration enabled it outlives the refresh window),
-    // so use it rather than pushing unauthenticated. See issue #75.
-    log.warn`BYOS auth: refresh failed, falling back to stored access token: ${(err as Error).message}`
-    return auth.access_token
+    // A rejected refresh is not proof the session died: Rodauth rotates
+    // refresh tokens on use, so a concurrent refresh (send path vs keepalive,
+    // each holding its own copy of the auth config) leaves the loser with an
+    // invalid refresh token → 400. See issue #75.
+    //
+    // A stored login recovers the case that is real - the server expired the
+    // session, which refreshing can never outlive. Without one, keep using the
+    // stored access token: it is usually still valid on the server (tokens
+    // live ~100 years where session expiration is off, and where it is on they
+    // outlive the refresh window), and a push with a genuinely dead token
+    // fails no worse than one with none.
+    log.warn`BYOS auth: refresh failed: ${(err as Error).message}`
+    return (
+      (await relogin(getBaseUrl(webhookUrl), auth, onTokenRefresh)) ??
+      auth.access_token
+    )
   }
 }

--- a/trmnl-ha/ha-trmnl/scheduler.ts
+++ b/trmnl-ha/ha-trmnl/scheduler.ts
@@ -25,6 +25,7 @@ import { JobManager } from './lib/scheduler/job-manager.js'
 import { CooldownTracker } from './lib/scheduler/cooldown-tracker.js'
 import {
   buildRefreshedAuthUpdate,
+  canRelogin,
   getValidAccessToken,
   isRefreshable,
 } from './lib/scheduler/byos-auth.js'
@@ -198,7 +199,9 @@ export class Scheduler {
         const auth = schedule.webhook_format?.byosConfig?.auth
         if (!schedule.webhook_url || !auth?.enabled) continue
 
-        if (!isRefreshable(auth)) {
+        // A saved login recovers past the refresh window, so only a schedule
+        // without one is genuinely stuck.
+        if (!isRefreshable(auth) && !canRelogin(auth)) {
           if (auth.access_token && !this.#deadTokensWarned.has(schedule.id)) {
             this.#deadTokensWarned.add(schedule.id)
             log.warn`BYOS tokens for "${schedule.name}" expired beyond the refresh window — re-authenticate in the schedule settings`

--- a/trmnl-ha/ha-trmnl/tests/unit/byos-auth.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/byos-auth.test.ts
@@ -3,7 +3,8 @@
  *
  * Covers:
  * - getBaseUrl() — pure URL parsing
- * - getValidAccessToken() — token validation and refresh flow
+ * - getValidAccessToken() — token validation, refresh and re-login flow
+ * - canRelogin() — stored credential detection
  * - login() — fetch-based login with error handling
  *
  * Uses globalThis.fetch override (scoped to this file) instead of
@@ -16,6 +17,7 @@
 import { describe, it, expect, beforeEach, afterAll, mock } from 'bun:test'
 import {
   buildRefreshedAuthUpdate,
+  canRelogin,
   getBaseUrl,
   getValidAccessToken,
   isRefreshable,
@@ -331,6 +333,132 @@ describe('byos-auth', () => {
       await getValidAccessToken('https://host.com/api', auth, onTokenRefresh)
 
       expect(onTokenRefresh).not.toHaveBeenCalled()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // canRelogin
+  // -------------------------------------------------------------------------
+
+  describe('#canRelogin', () => {
+    it('is true when both stored credentials are present', () => {
+      expect(
+        canRelogin({
+          enabled: true,
+          login_email: 'me@example.com',
+          login_password: 'secret',
+        }),
+      ).toBe(true)
+    })
+
+    it('is false when only the email was stored', () => {
+      expect(
+        canRelogin({ enabled: true, login_email: 'me@example.com' }),
+      ).toBe(false)
+    })
+
+    it('is false when no credentials were stored', () => {
+      expect(canRelogin({ enabled: true })).toBe(false)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // getValidAccessToken — re-login after the session expires
+  // -------------------------------------------------------------------------
+
+  describe('#getValidAccessToken re-login', () => {
+    /** Auth whose refresh window has closed, with credentials stored */
+    const expiredWithCredentials = (): ByosAuthConfig => ({
+      enabled: true,
+      access_token: 'dead',
+      refresh_token: 'dead-refresh',
+      obtained_at: Date.now() - 30 * 60 * 1000,
+      login_email: 'me@example.com',
+      login_password: 'secret',
+    })
+
+    /** Rejects the refresh, then answers the login with fresh tokens */
+    const mockRefreshFailsThenLogin = (): void => {
+      globalThis.fetch = mock(async (url: unknown) =>
+        String(url).endsWith('/login')
+          ? new Response(
+              JSON.stringify({
+                access_token: 'relogin-access',
+                refresh_token: 'relogin-refresh',
+              }),
+              { status: 200 },
+            )
+          : new Response('{"error":"expired JWT access token"}', {
+              status: 400,
+            }),
+      ) as unknown as typeof fetch
+    }
+
+    it('logs in again when the refresh is rejected', async () => {
+      const auth = expiredWithCredentials()
+      mockRefreshFailsThenLogin()
+
+      const result = await getValidAccessToken('https://host.com/api', auth)
+
+      expect(result).toBe('relogin-access')
+    })
+
+    it('persists the tokens the re-login returned', async () => {
+      const auth = expiredWithCredentials()
+      mockRefreshFailsThenLogin()
+
+      let persisted: unknown = null
+      await getValidAccessToken('https://host.com/api', auth, (tokens) => {
+        persisted = tokens
+      })
+
+      expect(persisted).toMatchObject({
+        access_token: 'relogin-access',
+        refresh_token: 'relogin-refresh',
+      })
+      expect(auth.access_token).toBe('relogin-access')
+    })
+
+    it('sends the stored credentials to the login endpoint', async () => {
+      const auth = expiredWithCredentials()
+      const requests = captureFetch()
+
+      await getValidAccessToken('https://host.com/api', auth)
+
+      const loginRequest = requests.find((request) =>
+        request.url.endsWith('/login'),
+      )
+      expect(JSON.parse(loginRequest?.init?.body as string)).toEqual({
+        login: 'me@example.com',
+        password: 'secret',
+      })
+    })
+
+    it('does not log in while the refresh still works', async () => {
+      const auth = expiredWithCredentials()
+      const requests = captureFetch()
+      mockFetch({
+        ok: true,
+        json: async () => ({
+          access_token: 'refreshed',
+          refresh_token: 'refreshed-refresh',
+        }),
+      })
+
+      await getValidAccessToken('https://host.com/api', auth)
+
+      expect(requests.some((request) => request.url.endsWith('/login'))).toBe(
+        false,
+      )
+    })
+
+    it('falls back to the stored access token when the re-login also fails', async () => {
+      const auth = expiredWithCredentials()
+      mockFetch({ ok: false, status: 401 })
+
+      const result = await getValidAccessToken('https://host.com/api', auth)
+
+      expect(result).toBe('dead')
     })
   })
 

--- a/trmnl-ha/ha-trmnl/types/domain.ts
+++ b/trmnl-ha/ha-trmnl/types/domain.ts
@@ -171,7 +171,7 @@ export interface ByosHanamiConfig {
   auth?: ByosAuthConfig
 }
 
-/** BYOS JWT authentication configuration (tokens only - no credentials stored) */
+/** BYOS JWT authentication configuration */
 export interface ByosAuthConfig {
   /** Enable JWT authentication */
   enabled: boolean
@@ -181,6 +181,14 @@ export interface ByosAuthConfig {
   refresh_token?: string
   /** Timestamp when tokens were obtained */
   obtained_at?: number
+  /**
+   * Login stored so the scheduler can re-authenticate itself once the server
+   * expires the session, which no amount of refreshing survives. Opt-in: the
+   * password is written to the schedules file in plain text, so it is only
+   * present when the user ticked "stay signed in".
+   */
+  login_email?: string
+  login_password?: string
 }
 
 /** Webhook format configuration */


### PR DESCRIPTION
The other half of #60. #103 stops our own Terminus add-on expiring sessions; this is for the servers we do not control — someone running Terminus from Compose, or anyone who wants expiry left on.

Terminus ends a session 24 hours after login and ties its API tokens to it. Refreshing resets the inactivity timer but never that cap, so a schedule breaks a day after setup and stays broken until someone signs in by hand. With **Stay signed in** ticked on a schedule, the scheduler signs in again itself and the schedule carries on.

It is opt-in because saving the login writes the password to the schedules file in plain text. That file already holds an access token which, against a server that does not expire sessions, is a credential of much the same power — but a password is a step further, so the tick says what it does and signing out clears both. I deliberately did not encrypt it: any key would have to sit beside the ciphertext, which buys the appearance of safety and nothing else.

Measured against a real Terminus 0.69.0 with all three session limits set to 60 seconds, the current behaviour as the control:

```
=== stay signed in OFF (today) ===        === stay signed in ON (new) ===
t=0    push: HTTP 200                      t=0    push: HTTP 200
t=70s  token changed: false                t=70s  token changed: true
t=70s  persisted new tokens: false         t=70s  persisted new tokens: true
t=70s  push: HTTP 400                      t=70s  push: HTTP 200
```

The control is what makes the right column mean anything: against a genuinely dead session no refresh can succeed, so the working token on the right can only have come from a fresh login.

Eight new specs, written failing first. 637 unit tests pass, typecheck and lint clean.