### PR TITLE
Added a notification for an expired BYOS session

### DIFF
--- a/trmnl-ha/docs/webhook-formats.md
+++ b/trmnl-ha/docs/webhook-formats.md
@@ -159,7 +159,7 @@ The scheduler refreshes tokens every minute once they are 10 minutes old, well i
 
 ### Sessions that expire
 
-Terminus ties its API tokens to a login session, and where session expiration is on it ends that session 24 hours after login however often the token is refreshed - refreshing resets the inactivity timer, never the lifetime cap. When it lapses, sends fail with `401` until somebody signs in again.
+Terminus ties its API tokens to a login session, and where session expiration is on it ends that session 24 hours after login however often the token is refreshed - refreshing resets the inactivity timer, never the lifetime cap. When it lapses, sends fail with `401`, and where no login is saved the add-on raises a Home Assistant notification asking you to sign in again.
 
 Two ways to stop that:
 

--- a/trmnl-ha/ha-trmnl/lib/ha-notify.ts
+++ b/trmnl-ha/ha-trmnl/lib/ha-notify.ts
@@ -1,0 +1,61 @@
+/**
+ * Home Assistant persistent notifications.
+ *
+ * The scheduler's failures are otherwise only visible in the add-on log, which
+ * nobody reads until screens have been stale for a day.
+ *
+ * @module lib/ha-notify
+ */
+
+import { hassToken, hassUrl } from '../const.js'
+import { schedulerLogger } from './logger.js'
+import type { Schedule } from '../types/domain.js'
+
+const log = schedulerLogger()
+
+/** Where to post, defaulting to the configured Home Assistant */
+export interface HaTarget {
+  url?: string
+  token?: string
+}
+
+/**
+ * Tells the user a BYOS schedule needs signing in again.
+ *
+ * Reuses one notification id per schedule so a daily expiry replaces its own
+ * notice instead of stacking up. Never throws - a failed notification must not
+ * take the scheduler tick with it.
+ */
+export async function notifyReauthRequired(
+  schedule: Pick<Schedule, 'id' | 'name'>,
+  { url = hassUrl, token = hassToken }: HaTarget = {},
+): Promise<void> {
+  if (!token) return
+
+  try {
+    const response = await fetch(
+      `${url}/api/services/persistent_notification/create`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          title: 'TRMNL: sign in to your BYOS server',
+          message:
+            `The saved session for "${schedule.name}" expired, so screens are no longer being sent. ` +
+            'Open the TRMNL add-on, pick the schedule and authenticate again. ' +
+            'Ticking "stay signed in" lets the add-on recover from this on its own.',
+          notification_id: `trmnl_byos_reauth_${schedule.id}`,
+        }),
+      },
+    )
+
+    if (!response.ok) {
+      log.warn`Could not notify Home Assistant of the expired BYOS session: HTTP ${response.status}`
+    }
+  } catch (err) {
+    log.warn`Could not notify Home Assistant of the expired BYOS session: ${(err as Error).message}`
+  }
+}

--- a/trmnl-ha/ha-trmnl/scheduler.ts
+++ b/trmnl-ha/ha-trmnl/scheduler.ts
@@ -29,6 +29,7 @@ import {
   getValidAccessToken,
   isRefreshable,
 } from './lib/scheduler/byos-auth.js'
+import { notifyReauthRequired } from './lib/ha-notify.js'
 import { sleep } from './lib/sleep.js'
 import {
   SCHEDULER_RELOAD_INTERVAL_MS,
@@ -205,6 +206,7 @@ export class Scheduler {
           if (auth.access_token && !this.#deadTokensWarned.has(schedule.id)) {
             this.#deadTokensWarned.add(schedule.id)
             log.warn`BYOS tokens for "${schedule.name}" expired beyond the refresh window — re-authenticate in the schedule settings`
+            void notifyReauthRequired(schedule)
           }
           continue
         }

--- a/trmnl-ha/ha-trmnl/tests/unit/ha-notify.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/ha-notify.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for Home Assistant persistent notifications.
+ *
+ * @see lib/ha-notify.ts
+ * @module tests/unit/ha-notify
+ */
+
+import { describe, it, expect, beforeEach, afterAll } from 'bun:test'
+import { notifyReauthRequired } from '../../lib/ha-notify.js'
+import { captureFetch, mockFetch, restoreFetch } from '../helpers/fetch-mock.js'
+
+afterAll(restoreFetch)
+
+const schedule = { id: 'abc123', name: 'Kitchen' }
+const ha = { url: 'http://homeassistant:8123', token: 'ha-token' }
+
+describe('ha-notify', () => {
+  beforeEach(restoreFetch)
+
+  describe('#notifyReauthRequired', () => {
+    it('calls the persistent notification service with the schedule name', async () => {
+      const requests = captureFetch()
+
+      await notifyReauthRequired(schedule, ha)
+
+      expect(requests[0]!.url).toBe(
+        'http://homeassistant:8123/api/services/persistent_notification/create',
+      )
+      expect(requests[0]!.init).toMatchObject({
+        method: 'POST',
+        headers: { Authorization: 'Bearer ha-token' },
+      })
+      const body = JSON.parse(requests[0]!.init?.body as string)
+      expect(body.message).toContain('Kitchen')
+    })
+
+    it('reuses one notification id per schedule so expiries do not stack up', async () => {
+      const requests = captureFetch()
+
+      await notifyReauthRequired(schedule, ha)
+      await notifyReauthRequired(schedule, ha)
+
+      const ids = requests.map(
+        (request) => JSON.parse(request.init?.body as string).notification_id,
+      )
+      expect(ids).toEqual(['trmnl_byos_reauth_abc123', 'trmnl_byos_reauth_abc123'])
+    })
+
+    it('stays quiet when no Home Assistant token is configured', async () => {
+      const requests = captureFetch()
+
+      await notifyReauthRequired(schedule, { url: ha.url, token: '' })
+
+      expect(requests).toHaveLength(0)
+    })
+
+    it('swallows a rejected request rather than failing the tick', async () => {
+      mockFetch({ ok: false, status: 401 })
+
+      expect(await notifyReauthRequired(schedule, ha)).toBeUndefined()
+    })
+
+    it('swallows an unreachable Home Assistant', async () => {
+      globalThis.fetch = (async () => {
+        throw new Error('ECONNREFUSED')
+      }) as unknown as typeof fetch
+
+      expect(await notifyReauthRequired(schedule, ha)).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
Last piece of #60. #104 lets a schedule recover on its own where a login is saved; this is for the case where it cannot, and somebody has to sign in.

Today the only sign is a line in the add-on log. That line has been there the whole time and the issue has still been reopened three times by people who could not work out why their display had stopped, so it now raises a Home Assistant notification instead.

It fires only where the session has lapsed and no login is saved, so anyone who ticked stay signed in is never asked to do something the scheduler is already doing. One notification id per schedule, so a repeat expiry replaces its own notice rather than stacking up. Every failure is swallowed — an unreachable Home Assistant must not take a scheduler tick down with it.

Five specs covering the request, the id reuse, the no-token case, a rejected call and an unreachable host. `lib/ha-notify.ts` is at 100% lines and functions; 642 unit tests pass and the coverage gate is green at 86.9%.

