### PR TITLE
Fixed schedules never firing on intervals longer than ten minutes

### DIFF
--- a/trmnl-ha/ha-trmnl/lib/scheduler/job-manager.ts
+++ b/trmnl-ha/ha-trmnl/lib/scheduler/job-manager.ts
@@ -5,8 +5,10 @@
  * interval schedules on a self-rescheduling timer, cron schedules (the advanced
  * escape hatch) on node-cron.
  *
- * Jobs are always destroyed and recreated on upsert so the cron callback closes
- * over fresh schedule data rather than a stale copy.
+ * A job survives a reload when its timing is unchanged: recreating one restarts
+ * its interval from zero, so a schedule reloaded more often than it fires would
+ * never fire at all (#108). Callbacks look their schedule up when they run, so a
+ * preserved job still sees edits.
  *
  * @module lib/scheduler/job-manager
  */
@@ -56,26 +58,47 @@ export function startIntervalJob(
   }
 }
 
+/** The fields that decide when a job fires. */
+type Timing = Pick<Schedule, 'cron' | 'interval_minutes'>
+
+function sameTiming(a: Timing, b: Timing): boolean {
+  return a.cron === b.cron && a.interval_minutes === b.interval_minutes
+}
+
+/** A running job alongside the timing it was started for. */
+interface RegisteredJob {
+  timing: Timing
+  job: ManagedJob
+}
+
 export class JobManager {
-  #jobs = new Map<string, ManagedJob>()
+  #jobs = new Map<string, RegisteredJob>()
 
   get jobCount(): number {
     return this.#jobs.size
   }
 
   /**
-   * Creates or replaces a schedule's job. Returns false (leaving any existing
-   * job untouched) when the schedule's interval or cron is invalid.
+   * Creates or replaces a schedule's job. Unchanged timing keeps the running job
+   * rather than restarting it. Returns false (leaving any existing job
+   * untouched) when the schedule's interval or cron is invalid.
    */
   upsertJob(
     schedule: Pick<Schedule, 'id' | 'name' | 'cron' | 'interval_minutes'>,
     callback: ScheduleCallback,
   ): boolean {
+    const timing = {
+      cron: schedule.cron,
+      interval_minutes: schedule.interval_minutes,
+    }
+    const existing = this.#jobs.get(schedule.id)
+    if (existing && sameTiming(existing.timing, timing)) return true
+
     const job = this.#createJob(schedule, callback)
     if (!job) return false
 
-    this.#jobs.get(schedule.id)?.stop()
-    this.#jobs.set(schedule.id, job)
+    existing?.job.stop()
+    this.#jobs.set(schedule.id, { timing, job })
     return true
   }
 
@@ -105,10 +128,10 @@ export class JobManager {
   }
 
   removeJob(id: string, name?: string): boolean {
-    const job = this.#jobs.get(id)
-    if (!job) return false
+    const registered = this.#jobs.get(id)
+    if (!registered) return false
 
-    job.stop()
+    registered.job.stop()
     this.#jobs.delete(id)
     log.info`Stopped job: ${name ?? id}`
     return true
@@ -117,9 +140,9 @@ export class JobManager {
   /** Stops jobs whose schedules no longer exist. */
   pruneInactiveJobs(activeIds: Set<string>): number {
     let pruned = 0
-    for (const [id, job] of this.#jobs) {
+    for (const [id, registered] of this.#jobs) {
       if (!activeIds.has(id)) {
-        job.stop()
+        registered.job.stop()
         this.#jobs.delete(id)
         log.info`Removed deleted schedule job: ${id}`
         pruned++
@@ -129,7 +152,7 @@ export class JobManager {
   }
 
   stopAll(): void {
-    for (const [, job] of this.#jobs) job.stop()
+    for (const [, registered] of this.#jobs) registered.job.stop()
     this.#jobs.clear()
   }
 }

--- a/trmnl-ha/ha-trmnl/scheduler.ts
+++ b/trmnl-ha/ha-trmnl/scheduler.ts
@@ -177,7 +177,7 @@ export class Scheduler {
 
       activeIds.add(schedule.id)
 
-      this.#jobManager.upsertJob(schedule, () => this.#runSchedule(schedule))
+      this.#jobManager.upsertJob(schedule, () => this.#runSchedule(schedule.id))
     }
 
     this.#jobManager.pruneInactiveJobs(activeIds)
@@ -229,8 +229,18 @@ export class Scheduler {
     }
   }
 
-  /** Cron callback: skips while cooling down, jitters, then executes. */
-  async #runSchedule(schedule: Schedule): Promise<void> {
+  /**
+   * Cron callback: loads the schedule, skips while cooling down, jitters, then
+   * executes.
+   *
+   * The job closes over the id rather than the schedule so it survives a reload
+   * without going stale.
+   */
+  async #runSchedule(scheduleId: string): Promise<void> {
+    const schedules = await loadSchedules()
+    const schedule = schedules.find((s) => s.id === scheduleId)
+    if (!schedule?.enabled) return
+
     const blockedUntil = this.#cooldowns.blockedUntil(schedule.id)
     if (blockedUntil !== null) {
       log.info`Skipping "${schedule.name}": server cooldown active until ${new Date(blockedUntil).toISOString()}`

--- a/trmnl-ha/ha-trmnl/scheduler.ts
+++ b/trmnl-ha/ha-trmnl/scheduler.ts
@@ -46,6 +46,11 @@ const log = schedulerLogger()
 /**
  * Detects whether loaded schedules differ from the previous reload.
  *
+ * BYOS auth is excluded: the keepalive rotates those tokens every 10 minutes,
+ * and counting a rotation as an edit re-registered every job, restarting the
+ * interval timers before a schedule slower than the token lifetime could fire
+ * (#108). Jobs read their schedule when they run, so none of them go stale.
+ *
  * @param schedules - Schedules loaded from disk this tick
  * @param lastSnapshot - Serialized snapshot from the previous reload
  * @returns New snapshot string when changed, null when identical
@@ -54,7 +59,9 @@ export function changedSnapshot(
   schedules: Schedule[],
   lastSnapshot: string,
 ): string | null {
-  const snapshot = JSON.stringify(schedules)
+  const snapshot = JSON.stringify(schedules, (key: string, value: unknown) =>
+    key === 'auth' ? undefined : value,
+  )
   return snapshot === lastSnapshot ? null : snapshot
 }
 

--- a/trmnl-ha/ha-trmnl/tests/unit/job-manager.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/job-manager.test.ts
@@ -2,7 +2,7 @@
  * @module tests/unit/job-manager
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { describe, it, expect, beforeEach, afterEach, jest } from 'bun:test'
 import { JobManager, startIntervalJob } from '../../lib/scheduler/job-manager.js'
 import { sleep } from '../../lib/sleep.js'
 import type { Schedule } from '../../types/domain.js'
@@ -67,6 +67,51 @@ describe('JobManager', () => {
       manager.upsertJob(buildJobInput({ interval_minutes: -1 }), noop)
 
       expect(manager.jobCount).toBe(1)
+    })
+
+    describe('when a reload re-upserts a running job', () => {
+      beforeEach(() => {
+        jest.useFakeTimers()
+      })
+
+      afterEach(() => {
+        jest.useRealTimers()
+      })
+
+      it('still fires on time when the timing is unchanged', () => {
+        let fired = 0
+        const schedule = buildJobInput({ interval_minutes: 3 })
+        manager.upsertJob(schedule, () => {
+          fired++
+        })
+
+        for (let minute = 0; minute < 3; minute++) {
+          jest.advanceTimersByTime(60_000)
+          manager.upsertJob(schedule, () => {
+            fired++
+          })
+        }
+
+        expect(fired).toBe(1)
+      })
+
+      it('restarts the timer when the timing changes', () => {
+        let fired = 0
+        manager.upsertJob(buildJobInput({ interval_minutes: 3 }), () => {
+          fired++
+        })
+
+        jest.advanceTimersByTime(60_000)
+        manager.upsertJob(buildJobInput({ interval_minutes: 5 }), () => {
+          fired++
+        })
+
+        jest.advanceTimersByTime(120_000)
+        expect(fired).toBe(0)
+
+        jest.advanceTimersByTime(180_000)
+        expect(fired).toBe(1)
+      })
     })
   })
 

--- a/trmnl-ha/ha-trmnl/tests/unit/scheduler.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/scheduler.test.ts
@@ -9,7 +9,23 @@
 
 import { describe, it, expect } from 'bun:test'
 import { changedSnapshot } from '../../scheduler.js'
-import { buildSchedule } from '../helpers/schedule-fixtures.js'
+import {
+  buildByosSchedule,
+  buildSchedule,
+} from '../helpers/schedule-fixtures.js'
+import type { Schedule } from '../../types/domain.js'
+
+/** A BYOS schedule whose stored tokens carry the given rotation stamp. */
+function byosWithTokens(stamp: number): Schedule[] {
+  const schedule = buildByosSchedule()
+  schedule.webhook_format!.byosConfig!.auth = {
+    enabled: true,
+    access_token: `access-${stamp}`,
+    refresh_token: `refresh-${stamp}`,
+    obtained_at: stamp,
+  }
+  return [schedule]
+}
 
 describe('changedSnapshot', () => {
   it('returns a snapshot on first load', () => {
@@ -41,5 +57,19 @@ describe('changedSnapshot', () => {
     const first = changedSnapshot([buildSchedule()], '')!
 
     expect(changedSnapshot([], first)).toBeTypeOf('string')
+  })
+
+  it('returns null when only the BYOS tokens rotated', () => {
+    const first = changedSnapshot(byosWithTokens(1000), '')!
+
+    expect(changedSnapshot(byosWithTokens(2000), first)).toBeNull()
+  })
+
+  it('returns a new snapshot when a rotation accompanies a real edit', () => {
+    const first = changedSnapshot(byosWithTokens(1000), '')!
+    const [edited] = byosWithTokens(2000)
+    edited!.interval_minutes = 30
+
+    expect(changedSnapshot([edited!], first)).toBeTypeOf('string')
   })
 })


### PR DESCRIPTION
Scheduled webhooks never fired on an interval longer than ten minutes: the BYOS keepalive rewrites a schedule's tokens every ten minutes, change detection read that as an edit and reloaded every job, and rebuilding an interval job restarts its timer from zero. Cron-mode schedules were unaffected.

- excludes `auth` from the reload's change detection, so a token rotation is no longer an edit
- keeps a running job when its `interval_minutes` and `cron` are unchanged, rather than destroying and recreating it
- passes the schedule id to the job callback so it loads the schedule when it fires, rather than closing over a copy

Either of the first two fixes the report on its own. Both are here because any other edit to a schedule would otherwise reset its timer as well.

Fixes #108
