### PR TITLE
Fixed a routine browser close being logged as a crash

### DIFF
--- a/trmnl-ha/ha-trmnl/screenshot.ts
+++ b/trmnl-ha/ha-trmnl/screenshot.ts
@@ -297,8 +297,12 @@ export class Browser {
           }),
         )
 
-        // Monitor browser process death
+        // Puppeteer fires this for our own close as well as for a crash.
+        // cleanup() clears #browser before closing, so a disconnect from the
+        // browser still held here is the crash, and anything else is us.
         browser.on('disconnected', () => {
+          if (this.#browser !== browser) return
+
           browserLog.error`Browser process disconnected!`
           this.#browser = undefined
           this.#page = undefined


### PR DESCRIPTION
Every idle browser cleanup logged `Browser process disconnected!` at error level, because Puppeteer fires the `disconnected` event for our own `close()` as well as for a dead process. The line that follows it is `Browser closed`, printed by the cleanup that caused the disconnect, so a healthy shutdown read as a capture having crashed the browser.

The listener now ignores a disconnect from a browser the instance no longer holds — `cleanup()` clears the reference before closing, so anything still held is a genuine crash.

There is no test: the only difference between the two paths is which line is logged, and there is no way to assert on log output in this project yet. Both were exercised by hand instead — an idle close logs nothing, and killing Chromium mid-life still logs the error and relaunches on the next request.

Second half of what was reported in #108, alongside #109.
