### PR TITLE
Fixed a capture beating a late frontend restyle

### DIFF
--- a/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
+++ b/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
@@ -423,26 +423,47 @@ export function readinessInternalsPresent(): boolean {
  * callbacks ensure the browser has composed and painted at least one frame.
  * This catches the gap between "loading indicators gone" and "pixels painted".
  */
+/**
+ * Waits for the rendered layout to stop changing.
+ *
+ * Frontend modules loaded as Lovelace resources (card-mod and friends) restyle
+ * cards after the dashboard reports itself ready, which resizes everything
+ * around them. Sampling the layout until it holds still catches that; a couple
+ * of animation frames returns before it has even started.
+ */
 export class WaitForPaintStability {
   #page: Page
+  #quietMs: number
+  #timeout: number
 
-  constructor(page: Page) {
+  constructor(page: Page, quietMs: number = 300, timeout: number = 3000) {
     this.#page = page
+    this.#quietMs = quietMs
+    this.#timeout = timeout
   }
 
   async call(): Promise<void> {
     try {
       await this.#page.waitForFunction(
-        () =>
-          new Promise((resolve) => {
-            requestAnimationFrame(() => {
-              requestAnimationFrame(() => resolve(true))
-            })
-          }),
-        { timeout: 2000 },
+        (quietMs: number) => {
+          const root = document.documentElement
+          const signature = `${root.scrollHeight}:${root.scrollWidth}:${document.querySelectorAll('*').length}`
+          const store = window as unknown as Record<string, unknown>
+          const seen = store['__trmnlLayout'] as
+            | { signature: string; since: number }
+            | undefined
+
+          if (seen?.signature !== signature) {
+            store['__trmnlLayout'] = { signature, since: Date.now() }
+            return false
+          }
+          return Date.now() - seen.since >= quietMs
+        },
+        { timeout: this.#timeout, polling: 100 },
+        this.#quietMs,
       )
     } catch (_err) {
-      log.debug`Paint stability check timed out`
+      log.debug`Layout stability wait timed out`
     }
   }
 }

--- a/trmnl-ha/ha-trmnl/tests/unit/navigation-commands.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/navigation-commands.test.ts
@@ -682,7 +682,7 @@ describe('WaitForPaintStability', () => {
     await cmd.call()
   })
 
-  it('uses 2 second timeout', async () => {
+  it('polls until the layout holds still', async () => {
     let capturedOptions: unknown
     const mockPage = {
       waitForFunction: async (_fn: unknown, opts: unknown) => {
@@ -693,10 +693,10 @@ describe('WaitForPaintStability', () => {
     const cmd = new WaitForPaintStability(mockPage)
     await cmd.call()
 
-    expect(capturedOptions).toEqual({ timeout: 2000 })
+    expect(capturedOptions).toEqual({ timeout: 3000, polling: 100 })
   })
 
-  it('passes a function that returns a promise (double-rAF)', async () => {
+  it('passes the layout sampler to the page', async () => {
     let capturedFn: unknown
     const mockPage = {
       waitForFunction: async (fn: unknown) => {


### PR DESCRIPTION
Font sizes set through card-mod were missing from some captures, reported in #101.

Lovelace resources like card-mod restyle cards after the dashboard reports itself ready. The stability check before capture waited two animation frames, which returns before that restyle has begun, so a cold browser over a slow link captured the unstyled layout.

- replaces the double-`requestAnimationFrame` check in `WaitForPaintStability` with a layout sample — document `scrollHeight`, `scrollWidth` and element count — polled until it holds still for 300ms, capped at 3s

Verified against a real Home Assistant behind a 250ms-per-chunk latency proxy with card-mod 4.2.1 installed: 4 of 5 cold captures carried the styles before, 8 of 8 after. Against a local Home Assistant capture time is unchanged at ~2.5s, since a settled dashboard satisfies the check on the first poll.

One case this does not cover: with card-mod registered only as a Lovelace `resources:` entry rather than through `frontend: extra_module_url`, it loads after the cards have already rendered and never restyles them at all — 0 of 6 cold captures carried the styles, and no amount of waiting helps. That is card-mod's own documented setup requirement and it warns about it in the console.
