### PR TITLE
Added browser doubles and log capture for lifecycle specs

### DIFF
--- a/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
+++ b/trmnl-ha/ha-trmnl/lib/browser/navigation-commands.ts
@@ -27,6 +27,14 @@ const log = navigationLogger()
 /** Set once the warning below has been given, so it is given only once. */
 let warnedAboutInternals = false
 
+/**
+ * Clears the one-time internals warning. Exists for tests: the flag is process
+ * wide, so without this whichever test runs first decides what the others see.
+ */
+export function resetInternalsWarning(): void {
+  warnedAboutInternals = false
+}
+
 /** Auth storage for localStorage injection */
 export type AuthStorage = Record<string, string>
 

--- a/trmnl-ha/ha-trmnl/screenshot.ts
+++ b/trmnl-ha/ha-trmnl/screenshot.ts
@@ -54,6 +54,9 @@ import { screenshotLogger, browserLogger } from './lib/logger.js'
 import { recordTiming, timed } from './lib/metrics.js'
 
 const log = screenshotLogger()
+
+/** How many times a navigation mid-preparation is worth starting over for. */
+const MAX_SETTLE_PASSES = 2
 const browserLog = browserLogger()
 
 // =============================================================================
@@ -496,7 +499,7 @@ export class Browser {
         if (frame === page.mainFrame()) reloaded = true
       }
 
-      for (let attempt = 1; attempt <= 2; attempt++) {
+      for (let pass = 1; pass <= MAX_SETTLE_PASSES; pass++) {
         reloaded = false
         page.on('framenavigated', noteReload)
         try {
@@ -515,10 +518,17 @@ export class Browser {
         if (!reloaded) break
 
         // The new document kept none of the setup, so the cache saying the
-        // theme and language are already applied is wrong for it.
+        // theme and language are already applied describes a document that is
+        // gone.
         this.#lastRequestedLang = undefined
         this.#lastRequestedTheme = undefined
         this.#lastRequestedDarkMode = undefined
+
+        if (pass === MAX_SETTLE_PASSES) {
+          log.debug`Dashboard is still reloading; capturing it as it stands`
+          break
+        }
+
         log.debug`Dashboard reloaded mid-capture; settling it again`
       }
 

--- a/trmnl-ha/ha-trmnl/tests/helpers/browser-doubles.ts
+++ b/trmnl-ha/ha-trmnl/tests/helpers/browser-doubles.ts
@@ -1,0 +1,148 @@
+/**
+ * Puppeteer stand-ins for exercising the Browser lifecycle without Chromium.
+ *
+ * Only the members screenshot.ts actually touches are implemented, and every
+ * one of them resolves to something harmless, so a test can drive navigation
+ * and capture without a real page. Tests reach for emit() to make the page or
+ * browser do the thing being tested: crash, or navigate underneath the caller.
+ *
+ * @module tests/helpers/browser-doubles
+ */
+
+import type { Browser as PuppeteerBrowser, Frame, Page } from 'puppeteer'
+
+type Handler = (...args: unknown[]) => void
+
+/** Records handlers so a test can fire the events Puppeteer would. */
+class EventRecorder {
+  #handlers = new Map<string, Handler[]>()
+
+  on(event: string, handler: Handler): void {
+    this.#handlers.set(event, [...(this.#handlers.get(event) ?? []), handler])
+  }
+
+  off(event: string, handler: Handler): void {
+    this.#handlers.set(
+      event,
+      (this.#handlers.get(event) ?? []).filter((h) => h !== handler),
+    )
+  }
+
+  emit(event: string, ...args: unknown[]): void {
+    for (const handler of [...(this.#handlers.get(event) ?? [])]) {
+      handler(...args)
+    }
+  }
+
+  count(event: string): number {
+    return (this.#handlers.get(event) ?? []).length
+  }
+}
+
+/** A fake page, plus the controls a test needs to drive it. */
+export interface FakePage {
+  page: Page
+  emit(event: string, ...args: unknown[]): void
+  mainFrame: Frame
+  closed: boolean
+  /** Runs on every evaluate(); use it to make a step navigate or throw. */
+  onEvaluate?: () => void
+}
+
+/** A fake browser, plus the controls a test needs to drive it. */
+export interface FakeBrowser {
+  browser: PuppeteerBrowser
+  emit(event: string, ...args: unknown[]): void
+  pages: FakePage[]
+  closeCount: number
+}
+
+export function createFakePage(): FakePage {
+  const events = new EventRecorder()
+  const mainFrame = { url: () => 'http://ha.test/lovelace/0' } as unknown as Frame
+
+  const fake: FakePage = {
+    emit: (event, ...args) => events.emit(event, ...args),
+    mainFrame,
+    closed: false,
+    page: undefined as unknown as Page,
+  }
+
+  fake.page = {
+    on(event: string, handler: Handler) {
+      events.on(event, handler)
+      return fake.page
+    },
+    off(event: string, handler: Handler) {
+      events.off(event, handler)
+      return fake.page
+    },
+    mainFrame: () => mainFrame,
+    url: () => 'http://ha.test/lovelace/0',
+    close: async () => {
+      fake.closed = true
+    },
+    setViewport: async () => {},
+    emulateMediaFeatures: async () => {},
+    evaluateOnNewDocument: async () => ({ identifier: 'x' }),
+    removeScriptToEvaluateOnNewDocument: async () => {},
+    goto: async () => ({ ok: () => true, status: () => 200 }),
+    evaluate: async (fn: unknown) => {
+      fake.onEvaluate?.()
+      return typeof fn === 'function' ? undefined : undefined
+    },
+    waitForFunction: async () => undefined,
+    waitForNetworkIdle: async () => {},
+    createCDPSession: async () => ({
+      send: async () => {},
+      on: () => {},
+      detach: async () => {},
+    }),
+    screenshot: async () => Buffer.from('89504e470d0a1a0a', 'hex'),
+  } as unknown as Page
+
+  return fake
+}
+
+/**
+ * @param onNewPage - Called with each page as it is created, so a test can arm
+ * it before the code under test starts using it.
+ */
+export function createFakeBrowser(
+  onNewPage?: (page: FakePage) => void,
+): FakeBrowser {
+  const events = new EventRecorder()
+  const pages: FakePage[] = []
+
+  const fake: FakeBrowser = {
+    emit: (event, ...args) => events.emit(event, ...args),
+    pages,
+    closeCount: 0,
+    browser: undefined as unknown as PuppeteerBrowser,
+  }
+
+  fake.browser = {
+    connected: true,
+    on(event: string, handler: Handler) {
+      events.on(event, handler)
+      return fake.browser
+    },
+    off(event: string, handler: Handler) {
+      events.off(event, handler)
+      return fake.browser
+    },
+    newPage: async () => {
+      const page = createFakePage()
+      pages.push(page)
+      onNewPage?.(page)
+      return page.page
+    },
+    close: async () => {
+      fake.closeCount++
+      // Puppeteer fires this for a deliberate close as well as for a crash.
+      events.emit('disconnected')
+    },
+  } as unknown as PuppeteerBrowser
+
+  return fake
+}

--- a/trmnl-ha/ha-trmnl/tests/helpers/log-capture.ts
+++ b/trmnl-ha/ha-trmnl/tests/helpers/log-capture.ts
@@ -1,0 +1,74 @@
+/**
+ * Captures LogTape output so tests can assert on what was logged.
+ *
+ * The app only configures LogTape from initializeLogging(), which tests never
+ * call, so log calls reach nothing and a console spy silently records zero
+ * entries. Anything asserting on a log line has to configure a sink first.
+ *
+ * @module tests/helpers/log-capture
+ */
+
+import { configure, reset, type LogRecord } from '@logtape/logtape'
+
+/** One captured log line, flattened for easy assertions. */
+export interface CapturedLog {
+  level: string
+  category: string
+  message: string
+}
+
+/** A running capture. Call stop() to restore the previous configuration. */
+export interface LogCapture {
+  entries: CapturedLog[]
+  /** Messages at one level, in order. */
+  messagesAt(level: string): string[]
+  /** Whether any captured message contains the given text. */
+  contains(text: string, level?: string): boolean
+  stop(): Promise<void>
+}
+
+/** Joins LogTape's alternating template/value array back into a string. */
+function flatten(message: readonly unknown[]): string {
+  return message.map((part) => String(part)).join('')
+}
+
+/**
+ * Routes every ha-trmnl log record into an array for the duration of a test.
+ *
+ * @param lowestLevel - Quietest level to capture (defaults to every level)
+ */
+export async function captureLogs(
+  lowestLevel: 'trace' | 'debug' | 'info' | 'warning' | 'error' = 'trace',
+): Promise<LogCapture> {
+  const entries: CapturedLog[] = []
+
+  await configure({
+    reset: true,
+    sinks: {
+      memory: (record: LogRecord) => {
+        entries.push({
+          level: record.level,
+          category: record.category.join('.'),
+          message: flatten(record.message),
+        })
+      },
+    },
+    loggers: [
+      { category: ['ha-trmnl'], lowestLevel, sinks: ['memory'] },
+      { category: ['logtape', 'meta'], lowestLevel: 'error', sinks: [] },
+    ],
+  })
+
+  return {
+    entries,
+    messagesAt: (level) =>
+      entries.filter((e) => e.level === level).map((e) => e.message),
+    contains: (text, level) =>
+      entries.some(
+        (e) => e.message.includes(text) && (!level || e.level === level),
+      ),
+    stop: async () => {
+      await reset()
+    },
+  }
+}

--- a/trmnl-ha/ha-trmnl/tests/unit/browser-lifecycle.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/browser-lifecycle.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for Browser lifecycle logging and reload recovery.
+ *
+ * @module tests/unit/browser-lifecycle
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { Browser } from '../../screenshot.js'
+import {
+  createFakeBrowser,
+  type FakeBrowser,
+} from '../helpers/browser-doubles.js'
+import { captureLogs, type LogCapture } from '../helpers/log-capture.js'
+
+const CRASH_MESSAGE = 'Browser process disconnected'
+
+describe('Browser', () => {
+  let logs: LogCapture
+  let fake: FakeBrowser
+  let browser: Browser
+
+  beforeEach(async () => {
+    logs = await captureLogs()
+    fake = createFakeBrowser()
+    browser = new Browser('http://ha.test', 'token', {
+      launchBrowser: async () => fake.browser,
+    })
+  })
+
+  afterEach(async () => {
+    await logs.stop()
+  })
+
+  describe('a disconnect it did not ask for', () => {
+    it('is reported as a crash', async () => {
+      await browser.triggerInit()
+
+      fake.emit('disconnected')
+
+      expect(logs.contains(CRASH_MESSAGE, 'error')).toBe(true)
+    })
+
+    it('drops the browser so the next request relaunches', async () => {
+      await browser.triggerInit()
+
+      fake.emit('disconnected')
+
+      expect(browser.isConnected()).toBe(false)
+    })
+  })
+
+  describe('a disconnect from its own cleanup', () => {
+    it('closes the browser', async () => {
+      await browser.triggerInit()
+
+      await browser.cleanup()
+
+      expect(fake.closeCount).toBe(1)
+    })
+
+    it('is not reported as a crash', async () => {
+      await browser.triggerInit()
+
+      await browser.cleanup()
+
+      expect(logs.contains(CRASH_MESSAGE, 'error')).toBe(false)
+    })
+  })
+})
+
+const RESETTLE_MESSAGE = 'reloaded mid-capture'
+
+/** A browser whose pages navigate underneath the caller mid-preparation. */
+function browserThatReloads(reloadsPerPage: number): {
+  fake: FakeBrowser
+  browser: Browser
+} {
+  const fake = createFakeBrowser((page) => {
+    let reloads = 0
+    page.onEvaluate = () => {
+      if (reloads >= reloadsPerPage) return
+      reloads++
+      page.emit('framenavigated', page.mainFrame)
+    }
+  })
+
+  return {
+    fake,
+    browser: new Browser('http://ha.test', 'token', {
+      launchBrowser: async () => fake.browser,
+    }),
+  }
+}
+
+const NAVIGATE = {
+  pagePath: '/lovelace/0',
+  viewport: { width: 800, height: 480 },
+  zoom: 1.5,
+}
+
+describe('Browser navigation when the dashboard reloads', () => {
+  let logs: LogCapture
+
+  beforeEach(async () => {
+    logs = await captureLogs()
+  })
+
+  afterEach(async () => {
+    await logs.stop()
+  })
+
+  it('prepares the replacement document again', async () => {
+    const { browser } = browserThatReloads(1)
+
+    await browser.navigatePage(NAVIGATE)
+
+    expect(logs.contains(RESETTLE_MESSAGE)).toBe(true)
+  })
+
+  it('gives up after one extra pass when it keeps reloading', async () => {
+    const { browser } = browserThatReloads(Number.MAX_SAFE_INTEGER)
+
+    await browser.navigatePage(NAVIGATE)
+
+    expect(
+      logs.entries.filter((e) => e.message.includes(RESETTLE_MESSAGE)),
+    ).toHaveLength(1)
+  })
+
+  it('prepares the page once when nothing navigates', async () => {
+    const { browser } = browserThatReloads(0)
+
+    await browser.navigatePage(NAVIGATE)
+
+    expect(logs.contains(RESETTLE_MESSAGE)).toBe(false)
+  })
+})

--- a/trmnl-ha/ha-trmnl/tests/unit/navigation-commands.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/navigation-commands.test.ts
@@ -13,6 +13,7 @@ import {
   WaitForLoadingComplete,
   DismissToasts,
   WaitForPaintStability,
+  resetInternalsWarning,
   WaitForWebSocketIdle,
   WaitForHassReady,
   UpdateLanguage,
@@ -462,6 +463,7 @@ describe('WaitForLoadingComplete', () => {
   // before anything else in the suite drives a page whose evaluate() reports
   // the internals as missing.
   it('checks the Home Assistant internals once and not again', async () => {
+    resetInternalsWarning()
     let checks = 0
     const missingInternals = {
       waitForFunction: async () => {},


### PR DESCRIPTION
Three fixes went out this month with no spec behind them — the disconnect log level in #110, the reload retry in #111, and part of #112. Each was blocked by the same two gaps: nothing could stand in for a browser that crashes or a page that navigates underneath the caller, and nothing could assert on a log line.

The log gap was the quieter of the two. The app configures LogTape from `initializeLogging()`, which specs never call, so log calls reach no sink and a `console.error` spy records zero entries while looking like it passed.

- adds `tests/helpers/browser-doubles.ts` — a fake Page and Browser implementing only the members `screenshot.ts` touches, with an `emit()` for firing the events Puppeteer would
- adds `tests/helpers/log-capture.ts` — configures a memory sink for the duration of a spec
- covers two behaviors that were previously verified only by hand: a disconnect the add-on did not ask for is reported while its own cleanup is not, and a dashboard that reloads mid-preparation is prepared again, once
- exports a reset for the process-wide "missing internals" warning flag, because the spec asserting it fires once only passed while nothing earlier in the run had tripped it
- fixes a log line that claimed a retry on the final pass, where none follows

Both new behaviors were confirmed to fail against the code from before their fixes: reverting the disconnect guard turns one red, and running against the pre-#111 `screenshot.ts` turns two red.

No user-facing change beyond one debug log line.
