### PR TITLE
Updated the webhook docs and UI to speak Terminus

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If running Home Assistant OS in Proxmox, set the VM host type to `host` for Chro
 | [Fetch URL (Pull Mode)](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#fetch-url-pull-mode) | On-demand screenshots via direct URL |
 | [Device Presets](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#device-presets) | Supported e-ink displays |
 | [Scheduled Captures](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#scheduled-captures) | Cron-based automation |
-| [Webhook Formats](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/docs/webhook-formats.md) | TRMNL, BYOS, and custom endpoints |
+| [Sending screenshots to a server](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/docs/webhook-formats.md) | TRMNL devices, Terminus, and custom endpoints |
 | [Troubleshooting](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#troubleshooting) | Common issues and fixes |
 | [Local Development](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#local-development) | Development setup |
 

--- a/trmnl-ha/DOCS.md
+++ b/trmnl-ha/DOCS.md
@@ -272,7 +272,7 @@ called.
 
 | Architecture | Description | Use Case |
 |--------------|-------------|----------|
-| **Pull (Fetch URL)** | Device requests image on-demand via HTTP GET | ESPHome, custom e-ink, TRMNL BYOS, testing |
+| **Pull (Fetch URL)** | Device requests image on-demand via HTTP GET | ESPHome, custom e-ink, Terminus, testing |
 | **Push (Webhook)** | Add-on POSTs to webhook on schedule | TRMNL devices, automated updates |
 
 **Pull mode** generates a fresh screenshot on every request. The browser launches automatically if not already running.
@@ -389,23 +389,19 @@ Presets auto-configure viewport, rotation, dithering, and format.
 
 ## Webhook Formats
 
-The add-on supports multiple webhook payload formats for different e-ink display backends:
+A schedule can send its screenshot in one of two shapes:
 
 | Format | Use Case |
 |--------|----------|
-| **Raw** (default) | TRMNL devices, custom endpoints |
-| **BYOS Hanami** | Self-hosted [Terminus / BYOS Hanami](https://github.com/usetrmnl/terminus) servers |
+| **Raw Image** (default) | TRMNL devices, custom endpoints |
+| **Terminus** | Your own [Terminus](https://github.com/usetrmnl/terminus) server |
 
-For BYOS Hanami, the add-on offers two **delivery modes**:
+For Terminus, the add-on sends a short message naming the screen, and Terminus fetches the image from the add-on. That means **Add-on URL** has to be an address **Terminus** can reach — often *not* `localhost`.
 
-- **URI mode** (recommended, required for Terminus ≥ 0.52.0): the add-on sends a URL; Terminus fetches the image itself. Set **Add-on URL** to an address **Terminus** can reach — often *not* `localhost`. See the guide for deployment topologies.
-- **Legacy base64 mode**: inlines the image in the JSON body. Only works on Terminus ≤ 0.51.0.
-
-See **[Webhook Formats Guide](docs/webhook-formats.md)** for:
-- Detailed format specifications and delivery mode selection
-- JWT authentication setup for BYOS, and what to do about sessions that expire
-- Deployment topology examples for the Add-on URL (Docker, LAN, reverse proxy)
-- How to add custom webhook formats
+See **[Sending screenshots to a server](docs/webhook-formats.md)** for:
+- What to put in each field
+- Signing in, and what to do when sessions expire
+- Which Add-on URL to use for your setup (Docker, LAN, reverse proxy)
 
 ---
 

--- a/trmnl-ha/README.md
+++ b/trmnl-ha/README.md
@@ -79,7 +79,7 @@ If running Home Assistant OS in Proxmox, set the VM host type to `host` for Chro
 | [Fetch URL (Pull Mode)](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#fetch-url-pull-mode) | On-demand screenshots via direct URL |
 | [Device Presets](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#device-presets) | Supported e-ink displays |
 | [Scheduled Captures](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#scheduled-captures) | Cron-based automation |
-| [Webhook Formats](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/docs/webhook-formats.md) | TRMNL, BYOS, and custom endpoints |
+| [Sending screenshots to a server](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/docs/webhook-formats.md) | TRMNL devices, Terminus, and custom endpoints |
 | [Troubleshooting](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#troubleshooting) | Common issues and fixes |
 | [Local Development](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/DOCS.md#local-development) | Development setup |
 

--- a/trmnl-ha/docs/webhook-formats.md
+++ b/trmnl-ha/docs/webhook-formats.md
@@ -1,61 +1,64 @@
-# Webhook Formats
+# Sending screenshots to a server
 
-When uploading screenshots via webhooks, the add-on supports multiple payload formats to integrate with different e-ink display backends.
+A schedule takes a screenshot of your dashboard and sends it somewhere. This page covers the two ways it can send, and how to set each one up.
 
-## Supported Formats
+If you are not sure which you need:
 
-| Format | Content-Type | Use Case |
-|--------|--------------|----------|
-| **Raw** (default) | `image/png`, `image/jpeg`, `image/bmp` | Direct binary upload to TRMNL or custom endpoints |
-| **BYOS Hanami** | `application/json` | Self-hosted [Terminus / BYOS Hanami](https://github.com/usetrmnl/terminus) servers |
+| Send it to | Use | Why |
+|---|---|---|
+| A TRMNL device, or anything that accepts an image | **Raw Image** | It posts the picture and nothing else. Nothing to configure. |
+| Your own [Terminus](https://github.com/usetrmnl/terminus) server | **Terminus** | Terminus wants the picture wrapped in a small message describing which screen it belongs to. |
+
+You pick this in the schedule editor, under **Webhook Format**.
 
 ---
 
-## Raw Format
+## Raw Image
 
-The default format sends the image binary directly as the request body. This is the simplest format and works with most webhook endpoints.
+The add-on posts the image on its own, as the whole body of the request.
 
-**Request:**
 ```http
 POST /your-webhook-endpoint
 Content-Type: image/png
 Authorization: Bearer <optional-token>
 
-<binary image data>
+<the image>
 ```
 
-**When to use:** TRMNL devices, custom webhook endpoints, any service expecting raw image uploads.
+That is all there is to it. Point **Webhook URL** at whatever should receive the picture and you are done.
 
 ---
 
-## BYOS Hanami Format
+## Terminus
 
-For self-hosted [Terminus / BYOS Hanami](https://github.com/usetrmnl/terminus) installations, this format wraps the screen metadata in a JSON payload and delivers the image to `POST /api/screens`.
+Terminus is TRMNL's self-hosted server — you run it yourself instead of using trmnl.com. It stores "screens", and each screen is one image with a name attached. The add-on sends screenshots to your server's `/api/screens` address.
 
-### Delivery Modes
+Set **Webhook URL** to that address, for example `https://terminus.example.com/api/screens`.
 
-Terminus supports two incompatible payload shapes depending on its version. The add-on exposes both via a **Delivery Mode** dropdown in the schedule UI.
+### The fields
 
-| Mode | Terminus versions | Image transport |
-|------|-------------------|-----------------|
-| **URI** (recommended) | `≥ 0.11.0`, required from `0.52.0` onward | Terminus fetches the image from the add-on over HTTP |
-| **Legacy base64** | `≤ 0.51.0` only | Add-on inlines the image as base64 in the JSON body |
+| Field | What to put in it |
+|---|---|
+| **Label** | The name you want to see in Terminus. Anything readable, like "Kitchen dashboard". |
+| **Screen Name** | A short id with no spaces, like `ha-dashboard`. Terminus uses it to recognize the same screen each time, so keep it the same once you have picked one. |
+| **Model ID** | Which device model this screen is for, taken from your Terminus setup. `1` if you only have one. |
+| **Delivery Mode** | Leave on **URI**. See below. |
+| **Add-on URL** | Where Terminus can find this add-on. This one catches people out — see [Setting the Add-on URL](#setting-the-add-on-url). |
 
-Base64 support was removed from Terminus in `0.52.0` (released 2026-04-01). New installations should pick **URI** mode; older deployments can stay on **Legacy base64** until they upgrade.
+The add-on also tells Terminus the image is already prepared for e-ink, so Terminus leaves it alone. The add-on does that conversion itself, and doing it twice makes the picture worse.
 
-### URI Mode
+### How it sends
 
-In URI mode, the add-on sends a small JSON payload referencing a screenshot endpoint on the add-on itself. Terminus then calls back to that URL, downloads the dithered image, and stores it.
+The add-on posts a short message naming the screen and where the picture can be collected. Terminus then comes back and downloads it.
 
-**Request:**
 ```http
 POST /api/screens
 Content-Type: application/json
-Authorization: <jwt-access-token>
+Authorization: <access token>
 
 {
   "screen": {
-    "uri": "http://192.168.1.100:10000/lovelace/0?viewport=800x480&dithering=&dither_method=floyd-steinberg&palette=gray-4",
+    "uri": "http://192.168.1.100:10000/output/ha-dashboard.png",
     "label": "Home Assistant",
     "name": "ha-dashboard",
     "model_id": "1",
@@ -64,241 +67,88 @@ Authorization: <jwt-access-token>
 }
 ```
 
-**Requirements:**
+So there are two trips: the add-on tells Terminus about the picture, then Terminus fetches it. That second trip is why the Add-on URL matters.
 
-- `preprocessed: true` tells Terminus to use the image as-is without running its own dithering. The add-on always sends preprocessed images since it dithers locally.
-- The add-on's screenshot endpoint must be reachable without authentication, or the Add-on URL must include any credentials Terminus needs.
-- If URI mode is selected but **Add-on URL** is blank, the add-on throws a clear error at delivery time rather than silently falling back.
+---
 
-#### Setting the Add-on URL
+## Setting the Add-on URL
 
-> ⚠️ **This is the URL Terminus will use to reach the add-on — not the URL you use in your browser.**
->
-> The Add-on URL field must resolve from *Terminus's* network vantage point, not yours. If Terminus runs in Docker on the same host, `http://localhost:10000` will **not** work — inside the Terminus container, `localhost` points at the container itself, and nothing is listening on port `10000` there.
+> ⚠️ **This is the address *Terminus* uses to reach the add-on. It is not the address you type into your browser.**
 
-Think of it as two asymmetric network hops:
+Those are often different, even when both programs run on the same machine. Three separate connections are involved, and each one starts somewhere else:
 
 ```
-You (browser) ──────▶ Add-on UI       (your browser resolves "localhost")
-Add-on ──────▶ Terminus               (webhook URL, see "Webhook URL" field)
-Terminus ──────▶ Add-on screenshot    (Add-on URL, see this section)
+You, in a browser  ──▶ the add-on's page     (whatever you type in the address bar)
+The add-on         ──▶ Terminus              (the Webhook URL field)
+Terminus           ──▶ the add-on's image    (the Add-on URL field — this one)
 ```
 
-The second and third hops resolve DNS from different vantage points, so the Webhook URL and the Add-on URL often need to be different strings even when both services are on the same physical machine.
+`localhost` means "the machine I am on", so it means something different depending on who says it. If Terminus runs in Docker and you tell it `http://localhost:10000`, it looks inside its own container, finds nothing there, and the send fails.
 
-Pick the value that matches your deployment topology:
+Pick the row that matches your setup:
 
 | Where Terminus runs | Set Add-on URL to | Notes |
 |---|---|---|
-| Docker on the same host as the add-on (Docker Desktop on Mac/Windows) | `http://host.docker.internal:10000` | Docker Desktop's built-in DNS name for the host machine |
-| Docker on the same Linux host | `http://172.17.0.1:10000` or your LAN IP | `172.17.0.1` is the default docker bridge gateway; LAN IP also works |
-| A different machine on the same LAN | `http://<add-on-lan-ip>:10000` | Use the add-on host's routable IP, never `localhost` |
-| Behind a reverse proxy / public URL | `https://trmnl.example.com` | Whatever public hostname forwards to the add-on's port 10000 |
-| As a Home Assistant add-on, accessed via ingress | The add-on's ingress URL | See your HA installation's external ingress configuration |
+| Docker on the same computer, using Docker Desktop (Mac or Windows) | `http://host.docker.internal:10000` | Docker Desktop's built-in name for the computer it runs on |
+| Docker on the same Linux computer | `http://172.17.0.1:10000`, or that computer's network address | `172.17.0.1` is Docker's default gateway on Linux |
+| A different computer on your network | `http://<address-of-the-add-on's-computer>:10000` | Its actual network address. Never `localhost`. |
+| Behind a reverse proxy or on a public address | `https://trmnl.example.com` | Whatever public address forwards to port 10000 |
+| As a Home Assistant add-on reached through ingress | The add-on's ingress address | See your Home Assistant setup |
 
-**Verification shortcut.** Before retrying a failed schedule, shell into the Terminus container and confirm it can reach the add-on:
+**Check it before anything else.** If a schedule fails, run this from inside Terminus and see whether it can reach the add-on at all:
 
 ```sh
 docker compose -p terminus-development exec web \
   curl -sI http://host.docker.internal:10000/health
-# Expected: HTTP/1.1 200 OK
+# You want: HTTP/1.1 200 OK
 ```
 
-If that curl fails, fix the URL before touching anything else — every downstream error (`ECONNREFUSED`, `improper image header` from MiniMagick, 500 from Terminus) traces back to this one setting.
+If that fails, fix the address before changing anything else. Nearly every error you will see downstream — `ECONNREFUSED`, `improper image header`, a 500 from Terminus — comes back to this one field.
 
-### Legacy Base64 Mode
+---
 
-Legacy mode embeds the image directly in the JSON body. Keep it selected only if your Terminus is `≤ 0.51.0`.
+## Signing in
 
-**Request:**
-```http
-POST /api/screens
-Content-Type: application/json
-Authorization: <jwt-access-token>
+Terminus asks for a token before it will accept anything. Turn on **JWT Authentication** in the schedule and use either option.
 
+**Option 1 — sign in here.** Type your Terminus email and password and press Authenticate. The add-on trades them for tokens and keeps those. It does not keep the password unless you tick "Stay signed in".
+
+**Option 2 — paste tokens you already have.** If you would rather not type your password into the add-on, or you want to script the setup, ask Terminus for tokens yourself:
+
+```sh
+curl -X POST https://terminus.example.com/login \
+  -H 'Content-Type: application/json' \
+  -d '{"login": "you@example.com", "password": "your-password"}'
+```
+
+Terminus answers with two tokens:
+
+```json
 {
-  "screen": {
-    "data": "<base64-encoded-image>",
-    "label": "Home Assistant",
-    "name": "ha-dashboard",
-    "model_id": "1",
-    "file_name": "ha-dashboard.png",
-    "preprocessed": true
-  }
+  "access_token": "...",
+  "refresh_token": "..."
 }
 ```
 
-### Backward Compatibility
+Paste both into the schedule. You only do this once — the access token lasts about 30 minutes, and the add-on quietly swaps the refresh token for a fresh pair (`POST /api/jwt`) before it runs out.
 
-Schedules created before this feature shipped have no `delivery_mode` field in their stored config. The add-on treats them as follows:
+### When sign-ins stop working
 
-- No `delivery_mode` + no Add-on URL → **Legacy base64** (preserves pre-existing behavior)
-- No `delivery_mode` + Add-on URL configured → **URI**
-- Explicit `delivery_mode: 'data'` → **Legacy base64** (user choice wins even if Add-on URL is set)
-- Explicit `delivery_mode: 'uri'` → **URI** (throws if Add-on URL is missing)
+Terminus can be set to end a session 24 hours after you signed in, no matter how active it has been. Refreshing keeps the session from going idle, but it cannot extend that 24-hour ceiling. When the session ends, sends fail with a `401` and the add-on raises a Home Assistant notification asking you to sign in again.
 
-### Configuration Fields
+Two ways to avoid that:
 
-| Field | Description |
-|-------|-------------|
-| `label` | Display name shown in BYOS UI |
-| `name` | Unique screen identifier (slug format) |
-| `model_id` | BYOS device model ID (from your BYOS setup) |
-| `preprocessed` | Whether the image is already optimized for e-ink (always `true` from the add-on) |
-| `delivery_mode` | `'uri'` or `'data'`. Omitted on legacy schedules. |
-| `addon_base_url` | URL of this add-on as reachable **from Terminus**, required for URI mode. See [Setting the Add-on URL](#setting-the-add-on-url). |
-
-### JWT Authentication
-
-BYOS requires JWT authentication. You can either:
-
-1. **Login via UI:** Enter your BYOS credentials in the schedule settings. The add-on exchanges them for tokens.
-2. **Manual tokens:** Paste your access and refresh tokens directly if you prefer not to enter credentials.
-
-The scheduler refreshes tokens every minute once they are 10 minutes old, well inside Terminus' 30 minute access token window.
-
-### Sessions that expire
-
-Terminus ties its API tokens to a login session, and where session expiration is on it ends that session 24 hours after login however often the token is refreshed - refreshing resets the inactivity timer, never the lifetime cap. When it lapses, sends fail with `401`, and where no login is saved the add-on raises a Home Assistant notification asking you to sign in again.
-
-Two ways to stop that:
-
-- **Stay signed in**, in the schedule's JWT settings. The add-on saves your BYOS login and signs in again by itself when the session lapses. The password is stored in plain text in the add-on's schedules file, alongside the access token that already lives there, so treat the two the same. Leave it off if your server does not expire sessions.
-- **Turn expiry off on the server.** The [Terminus add-on](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-terminus/DOCS.md) does not expire sessions unless you switch **Session expiration** on. Running Terminus yourself with Docker Compose, set `SESSION_EXPIRATION_ENABLED=false` - and note it has to appear in the compose file's `environment:` block, not only in `.env`, or the container never sees it. To keep expiry but make it longer, raise `API_ACCESS_TOKEN_PERIOD`, `SESSION_INACTIVITY_LIMIT` and `SESSION_LIFETIME_LIMIT` together; the shortest of the three is what ends the session.
-
-### 422 Error Handling
-
-If BYOS returns `422 Unprocessable Entity` (screen already exists), the add-on automatically:
-1. Lists existing screens via `GET /api/screens`
-2. Finds and deletes the screen with matching `model_id`
-3. Retries the upload
+- **Tick "Stay signed in"** in the schedule. The add-on saves your Terminus password and signs in again by itself. Worth knowing: the password is stored in plain text in the add-on's schedules file, next to the token that already lives there. Treat both the same way. Leave this off if your server does not expire sessions.
+- **Turn expiry off on the server.** The [Terminus add-on](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-terminus/DOCS.md) leaves sessions alone unless you switch **Session expiration** on. Running Terminus yourself with Docker Compose, set `SESSION_EXPIRATION_ENABLED=false` — and put it in the compose file's `environment:` block, not only in `.env`, or the container never sees it. To keep expiry but stretch it out, raise `API_ACCESS_TOKEN_PERIOD`, `SESSION_INACTIVITY_LIMIT` and `SESSION_LIFETIME_LIMIT` together; whichever is shortest is what ends the session.
 
 ---
 
-## Adding Custom Formats
+## If the screen already exists
 
-The webhook system uses a **Strategy Pattern** for extensibility. To add a new format:
-
-### 1. Define the Format Type
-
-Add your format to `types/domain.ts`:
-
-```typescript
-// Add to WebhookFormat union type
-export type WebhookFormat = 'raw' | 'byos-hanami' | 'your-format'
-
-// Add config interface if needed
-export interface YourFormatConfig {
-  apiKey: string
-  // ... other fields
-}
-```
-
-### 2. Create a Transformer
-
-Add a new file `lib/scheduler/your-format-transformer.ts` or add to `webhook-formats.ts`:
-
-```typescript
-import type { FormatTransformer, WebhookPayload } from './webhook-formats.js'
-import type { ImageFormat } from '../../types/domain.js'
-
-export class YourFormatTransformer implements FormatTransformer {
-  transform(
-    imageBuffer: Buffer,
-    format: ImageFormat,
-    config?: YourFormatConfig,
-    screenshotUrl?: string,
-  ): WebhookPayload {
-    // Transform the image buffer into your payload format.
-    // `screenshotUrl` is only set for URI-mode formats (see BYOS Hanami).
-    // Formats that inline the image can ignore it.
-    return {
-      body: JSON.stringify({
-        image: imageBuffer.toString('base64'),
-        // ... your format's structure
-      }),
-      contentType: 'application/json',
-    }
-  }
-}
-```
-
-### 3. Register the Transformer
-
-Update `getTransformer()` in `lib/scheduler/webhook-formats.ts`:
-
-```typescript
-export function getTransformer(
-  formatConfig?: WebhookFormatConfig | null,
-): FormatTransformer {
-  const format = formatConfig?.format ?? 'raw'
-
-  switch (format) {
-    case 'byos-hanami':
-      return new ByosHanamiFormatTransformer()
-    case 'your-format':
-      return new YourFormatTransformer()
-    default:
-      return new RawFormatTransformer()
-  }
-}
-```
-
-### 4. Add UI Controls (Optional)
-
-If your format needs configuration, add form fields in `html/js/ui-renderer.ts`:
-
-```typescript
-// In #renderWebhookFormatSection()
-if (format === 'your-format') {
-  html += `
-    <div class="form-group">
-      <label>API Key</label>
-      <input type="text" name="your_api_key" value="${config?.apiKey ?? ''}" />
-    </div>
-  `
-}
-```
-
-### 5. Write Tests
-
-Add tests in `tests/unit/webhook-formats.test.ts`:
-
-```typescript
-describe('YourFormatTransformer', () => {
-  it('transforms image to your format', () => {
-    const transformer = new YourFormatTransformer()
-    const result = transformer.transform(testBuffer, 'png', { apiKey: 'test' })
-
-    expect(result.contentType).toBe('application/json')
-    // ... verify payload structure
-  })
-})
-```
+Terminus answers `422` when a screen with that model is already there. The add-on handles it: it looks up the existing screens, removes the one with the same Model ID, and sends again. You do not need to do anything.
 
 ---
 
-## Architecture Overview
+## Older Terminus servers
 
-```
-Schedule Execution
-       ↓
-ScheduleExecutor.call()
-       ↓
-#buildScreenshotUrl(schedule)   ← URI mode only; undefined otherwise
-       ↓
-uploadToWebhook(options)
-       ↓
-getTransformer(webhookFormat)   ← Strategy selection
-       ↓
-transformer.transform(buffer, format, config, screenshotUrl)
-       ↓                         ← BYOS transformer branches on delivery_mode
-fetch(webhookUrl, { body, headers })
-```
-
-For BYOS in URI mode, Terminus then performs a second round-trip back to the add-on's screenshot endpoint to download the actual image.
-
-The transformer is responsible for:
-- Converting the image buffer to the target payload format
-- Setting the appropriate `Content-Type` header
-- Encoding data as needed (base64, multipart, etc.)
+Terminus used to accept the image inside the message itself, rather than fetching it. That was removed in Terminus `0.52.0`. The **Legacy base64** delivery mode still exists for anyone running `0.51.0` or older, and it is the only reason to move off **URI**. If you are on a current Terminus — including the Terminus add-on in this repository — leave it on URI.

--- a/trmnl-ha/ha-trmnl/html/js/app.ts
+++ b/trmnl-ha/ha-trmnl/html/js/app.ts
@@ -554,7 +554,7 @@ class App {
       const authEnabled = checkbox('s_byos_auth_enabled')
       const rawDeliveryMode = select('s_byos_delivery_mode')
       const deliveryMode: ByosDeliveryMode =
-        rawDeliveryMode === 'uri' ? 'uri' : BYOS_DEFAULT_DELIVERY_MODE
+        rawDeliveryMode === 'data' ? 'data' : BYOS_DEFAULT_DELIVERY_MODE
 
       // Preserve existing auth tokens (managed by byosLogin/byosLogout, not form)
       // If auth is enabled but no tokens yet, create empty auth object with enabled: true

--- a/trmnl-ha/ha-trmnl/html/js/ui-renderer.ts
+++ b/trmnl-ha/ha-trmnl/html/js/ui-renderer.ts
@@ -318,13 +318,13 @@ export class RenderScheduleContent {
             onchange="window.app.toggleWebhookFormat(this.value)"
             title="Payload format for webhook requests">
             <option value="raw" ${currentFormat === 'raw' ? 'selected' : ''}>Raw Image (default)</option>
-            <option value="byos-hanami" ${currentFormat === 'byos-hanami' ? 'selected' : ''}>BYOS Hanami API</option>
+            <option value="byos-hanami" ${currentFormat === 'byos-hanami' ? 'selected' : ''}>Terminus</option>
           </select>
-          <p class="text-xs text-gray-500 mt-1">Raw: sends binary image | BYOS: JSON-wrapped base64 for self-hosted TRMNL</p>
+          <p class="text-xs text-gray-500 mt-1">Raw: sends the image itself | Terminus: sends JSON to your own Terminus server</p>
         </div>
 
         <div id="byosConfigSection" class="${showByosFields ? '' : 'hidden'} mt-3 p-3 rounded-md" style="background-color: #f9fafb; border: 1px solid #e5e7eb">
-          <p class="text-xs font-medium text-gray-600 mb-2">BYOS Hanami Configuration (/api/screens)</p>
+          <p class="text-xs font-medium text-gray-600 mb-2">Terminus Configuration (/api/screens)</p>
           <div class="space-y-2">
             <div>
               <label class="block text-xs text-gray-600 mb-1">Label</label>
@@ -332,7 +332,7 @@ export class RenderScheduleContent {
                 class="w-full px-2 py-1 text-sm border rounded-md" style="border-color: var(--primary-light)"
                 onchange="window.app.updateScheduleFromForm()"
                 placeholder="Home Assistant"
-                title="Display label shown in BYOS dashboard" />
+                title="Display label shown in Terminus" />
             </div>
             <div>
               <label class="block text-xs text-gray-600 mb-1">Screen Name</label>
@@ -348,7 +348,7 @@ export class RenderScheduleContent {
                 class="w-full px-2 py-1 text-sm border rounded-md" style="border-color: var(--primary-light)"
                 onchange="window.app.updateScheduleFromForm()"
                 placeholder="1"
-                title="BYOS model ID for your device" />
+                title="Terminus model ID for your device" />
             </div>
             <div>
               <label class="block text-xs text-gray-600 mb-1">Delivery Mode</label>
@@ -378,7 +378,7 @@ export class RenderScheduleContent {
               <input type="checkbox" id="s_byos_auth_enabled" ${byosConfig?.auth?.enabled ? 'checked' : ''}
                 class="h-4 w-4 border-gray-300 rounded"
                 onchange="window.app.toggleByosAuth(this.checked)"
-                title="Enable JWT authentication for BYOS API" />
+                title="Enable JWT authentication for the Terminus API" />
               JWT Authentication
             </label>
             <div id="byosAuthFields" class="${byosConfig?.auth?.enabled ? '' : 'hidden'}">
@@ -452,7 +452,7 @@ export class RenderScheduleContent {
           </div>
 
           <p class="text-xs text-gray-500 mt-2">
-            <a href="https://github.com/usetrmnl/byos_hanami/blob/main/doc/api.adoc#screens" target="_blank" class="underline" style="color: var(--primary)">BYOS Hanami docs</a>
+            <a href="https://github.com/usetrmnl/terminus/blob/main/doc/api.adoc#screens" target="_blank" class="underline" style="color: var(--primary)">Terminus API docs</a>
           </p>
         </div>
       </div>

--- a/trmnl-ha/ha-trmnl/html/js/ui-renderer.ts
+++ b/trmnl-ha/ha-trmnl/html/js/ui-renderer.ts
@@ -16,7 +16,7 @@
  */
 
 import type { Schedule } from '../../types/domain.js'
-import { BYOS_DEFAULT_DELIVERY_MODE } from '../shared/byos-constants.js'
+import { deliveryModeFor } from '../shared/byos-constants.js'
 import type { PaletteOption } from './palette-options.js'
 import { buildScreenshotParams } from '../shared/build-screenshot-params.js'
 import { resolveScreenshotTarget } from '../shared/screenshot-target.js'
@@ -308,6 +308,7 @@ export class RenderScheduleContent {
     const currentFormat = s.webhook_format?.format ?? 'raw'
     const byosConfig = s.webhook_format?.byosConfig
     const showByosFields = currentFormat === 'byos-hanami'
+    const deliveryMode = deliveryModeFor(byosConfig)
 
     return `
       <div id="webhookFormatSection" >
@@ -355,12 +356,12 @@ export class RenderScheduleContent {
                 class="w-full px-2 py-1 text-sm border rounded-md" style="border-color: var(--primary-light)"
                 onchange="window.app.toggleByosDeliveryMode(this.value)"
                 title="How Terminus receives the screenshot">
-                <option value="data" ${(byosConfig?.delivery_mode ?? BYOS_DEFAULT_DELIVERY_MODE) === 'data' ? 'selected' : ''}>Legacy base64 (Terminus ≤ 0.51.0)</option>
-                <option value="uri" ${byosConfig?.delivery_mode === 'uri' ? 'selected' : ''}>URI (Terminus ≥ 0.52.0, recommended)</option>
+                <option value="uri" ${deliveryMode === 'uri' ? 'selected' : ''}>URI (recommended)</option>
+                <option value="data" ${deliveryMode === 'data' ? 'selected' : ''}>Legacy base64 (Terminus ≤ 0.51.0 only)</option>
               </select>
-              <p class="text-xs text-gray-500 mt-1">Base64 was removed in Terminus 0.52.0. Pick URI if you're on 0.52.0 or newer.</p>
+              <p class="text-xs text-gray-500 mt-1">Terminus stopped accepting base64 in 0.52.0. Stay on URI unless your server is older than that.</p>
             </div>
-            <div id="s_byos_addon_url_field" class="${(byosConfig?.delivery_mode ?? BYOS_DEFAULT_DELIVERY_MODE) === 'uri' ? '' : 'hidden'}">
+            <div id="s_byos_addon_url_field" class="${deliveryMode === 'uri' ? '' : 'hidden'}">
               <label class="block text-xs text-gray-600 mb-1">Add-on URL</label>
               <input type="text" id="s_byos_addon_url" value="${byosConfig?.addon_base_url || ''}"
                 class="w-full px-2 py-1 text-sm border rounded-md" style="border-color: var(--primary-light)"

--- a/trmnl-ha/ha-trmnl/html/shared/byos-constants.ts
+++ b/trmnl-ha/ha-trmnl/html/shared/byos-constants.ts
@@ -8,11 +8,28 @@
  * @module shared/byos-constants
  */
 
-import type { ByosDeliveryMode } from '../../types/domain.js'
+import type { ByosDeliveryMode, ByosHanamiConfig } from '../../types/domain.js'
 
 /**
- * Default delivery mode shown in the UI when a schedule has no explicit choice.
- * Keep in sync with the backward-compat branch in
- * `ByosHanamiFormatTransformer#selectMode`.
+ * Delivery mode for a schedule that has never chosen one. Terminus dropped
+ * base64 in 0.52.0, so a new schedule that stays on the default has to be one
+ * Terminus can still accept.
  */
-export const BYOS_DEFAULT_DELIVERY_MODE: ByosDeliveryMode = 'data'
+export const BYOS_DEFAULT_DELIVERY_MODE: ByosDeliveryMode = 'uri'
+
+/**
+ * Delivery mode to show for a schedule's stored config.
+ *
+ * New schedules get the default; stored ones get whatever the transformer
+ * would actually pick, so the dropdown never disagrees with what gets sent.
+ *
+ * Keep in sync with `ByosHanamiFormatTransformer#selectMode`.
+ */
+export function deliveryModeFor(
+  config?: Pick<ByosHanamiConfig, 'delivery_mode' | 'addon_base_url'>,
+): ByosDeliveryMode {
+  if (!config) return BYOS_DEFAULT_DELIVERY_MODE
+  if (config.delivery_mode) return config.delivery_mode
+
+  return config.addon_base_url ? 'uri' : 'data'
+}

--- a/trmnl-ha/ha-trmnl/tests/unit/webhook-formats.test.ts
+++ b/trmnl-ha/ha-trmnl/tests/unit/webhook-formats.test.ts
@@ -13,6 +13,7 @@ import {
   getTransformer,
 } from '../../lib/scheduler/webhook-formats.js'
 import type { WebhookFormatConfig } from '../../types/domain.js'
+import { deliveryModeFor } from '../../html/shared/byos-constants.js'
 
 describe('RawFormatTransformer', () => {
   const transformer = new RawFormatTransformer()
@@ -222,5 +223,21 @@ describe('getTransformer factory', () => {
     const transformer = getTransformer(config)
 
     expect(transformer).toBeInstanceOf(RawFormatTransformer)
+  })
+})
+
+describe('deliveryModeFor', () => {
+  it('defaults a new schedule to uri', () => {
+    expect(deliveryModeFor()).toBe('uri')
+  })
+
+  it('keeps an explicit choice', () => {
+    expect(deliveryModeFor({ delivery_mode: 'data' })).toBe('data')
+    expect(deliveryModeFor({ delivery_mode: 'uri' })).toBe('uri')
+  })
+
+  it('reads a stored schedule the way the transformer does', () => {
+    expect(deliveryModeFor({})).toBe('data')
+    expect(deliveryModeFor({ addon_base_url: 'http://host:10000' })).toBe('uri')
   })
 })

--- a/trmnl-terminus/DOCS.md
+++ b/trmnl-terminus/DOCS.md
@@ -43,7 +43,7 @@ To add another variable from the Terminus docs, add the lowercased key to `schem
 
 This is the one option the add-on sets a default for. Terminus expires a session after 30 minutes idle and 24 hours in total, and ties its API tokens to that session. Anything pushing screens on a schedule cannot survive those limits unattended: refreshing resets the inactivity timer but never the lifetime cap, so the session lapses a day after login however diligently the token is refreshed, and every push then fails until somebody signs in by hand. Sessions therefore do not expire unless you switch this on.
 
-Turn it on if the server is reachable beyond your trusted network, and expect to re-authenticate any BYOS push schedules once per lifetime. The [TRMNL add-on](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/docs/webhook-formats.md) can save its login and sign in again on its own if you would rather keep expiry on.
+Turn it on if the server is reachable beyond your trusted network, and expect to re-authenticate any Terminus push schedules once per lifetime. The [TRMNL add-on](https://github.com/usetrmnl/trmnl-home-assistant/blob/main/trmnl-ha/docs/webhook-formats.md) can save its login and sign in again on its own if you would rather keep expiry on.
 
 Raising `api_access_token_period` on its own does not extend a session: `session_inactivity_limit` and `session_lifetime_limit` still apply, and the shortest of the three is what ends it. Move all three together.
 


### PR DESCRIPTION
Brooke asked for the webhook format docs to match Terminus terminology. Working through that turned up a bug behind it, so this does both.

A brand new schedule preselected `Legacy base64` and hid the Add-on URL field, so the first send went out in a shape Terminus has refused since `0.52.0`. The Terminus add-on in this repository ships `0.70.0`.

- flips the default delivery mode to `uri`
- gives the dropdown and the transformer one shared `deliveryModeFor`, so a stored schedule shows the mode it actually sends
- leaves saved schedules on the mode they already have

Before, on a new schedule:

![Before](https://github.com/user-attachments/assets/ec6ed3c2-deb8-429f-8af7-4090140d3965)

After:

![After](https://github.com/user-attachments/assets/611d25ad-5505-4c47-a42f-47cdd70c3852)

The guide is rewritten for people who do not already know the protocol — task ordered, plain language, and Terminus throughout instead of BYOS and Hanami. It also:

- documents asking Terminus for tokens over the API, rather than only saying tokens can be pasted
- drops the transformer walkthrough, which described how a contributor adds a payload format to this add-on and was never about Terminus
- drops the URI payload example, which still showed a live screenshot URL that has pointed at a saved file since #74
- keeps base64 as a closing note, since the dropdown still offers it to anyone on Terminus `0.51.0` or older

UI labels, tooltips and the API docs link say Terminus too. The stored `byos-hanami` format value is untouched, so existing schedules keep working.
